### PR TITLE
UDENG-2995: integration tests and adding a builder API for constructing replies

### DIFF
--- a/aa-prompt-client/src/lib.rs
+++ b/aa-prompt-client/src/lib.rs
@@ -16,6 +16,12 @@ pub enum Error {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
 
+    #[error("invalid custom permissions: requested={requested:?} but available={available:?}")]
+    InvalidCustomPermissions {
+        requested: Vec<String>,
+        available: Vec<String>,
+    },
+
     #[error("{uri} is not valid: {reason}")]
     InvalidUri { reason: &'static str, uri: String },
 

--- a/aa-prompt-client/src/main.rs
+++ b/aa-prompt-client/src/main.rs
@@ -1,5 +1,5 @@
 use aa_prompt_client::{
-    snapd_client::{PromptId, SnapdSocketClient},
+    snapd_client::{Action, PromptId, SnapdSocketClient},
     Result,
 };
 use std::io::{stdin, stdout, Write};
@@ -54,9 +54,9 @@ async fn run_simple_client(mut c: SnapdSocketClient) -> Result<()> {
             println!("{}", p.summary());
 
             let reply = if should_allow()? {
-                p.into_allow_once()
+                p.into_reply(Action::Allow)
             } else {
-                p.into_deny_once()
+                p.into_reply(Action::Deny)
             };
 
             if let Err(e) = c.reply_to_prompt(&id, reply).await {

--- a/aa-prompt-client/tests/integration.rs
+++ b/aa-prompt-client/tests/integration.rs
@@ -1,11 +1,14 @@
 //! Integration tests against a running snapd supporting apparmor-prompting
 //!
-//! These tests are written to interact with the system's running snapd process with
-//! the apparmor-prompting feature enabled inside of a VM that has been set up using
-//! the Makefile targets outlined in the README of this repo.
+//! These tests are written to interact with the system's running snapd process with the
+//! apparmor-prompting feature enabled inside of a VM that has been set up using the Makefile
+//! targets outlined in the README of this repo.
+//!
+//! Creation of the SnapdSocketClient needs to be handled before spawning the test snap so that
+//! polling `after` is correct to pick up the prompt.
 use aa_prompt_client::{
-    snapd_client::{Action, Lifespan, SnapdSocketClient},
-    Result,
+    snapd_client::{Action, Prompt, PromptId, SnapdSocketClient},
+    Error, Result,
 };
 use serial_test::serial;
 use simple_test_case::test_case;
@@ -56,6 +59,39 @@ fn setup_test_dir(subdir: Option<&str>, files: &[(&str, &str)]) -> io::Result<(S
     Ok((prefix, path))
 }
 
+async fn expect_single_prompt(
+    c: &mut SnapdSocketClient,
+    expected_path: &str,
+    expected_permissions: &[&str],
+) -> (PromptId, Prompt) {
+    let mut pending = match c.pending_prompts().await {
+        Ok(pending) => pending,
+        Err(e) => panic!("error pulling pending prompts: {e}"),
+    };
+    assert_eq!(pending.len(), 1, "expected a single prompt");
+
+    let id = pending.remove(0);
+    let p = match c.prompt_details(&id).await {
+        Ok(p) => p,
+        Err(e) => panic!("error pulling prompt details: {e}"),
+    };
+
+    assert_eq!(p.snap(), TEST_SNAP);
+    assert_eq!(p.path(), expected_path);
+    assert_eq!(p.requested_permissions(), expected_permissions);
+
+    (id, p)
+}
+
+// Included as a test to help with identifying when the VM hasn't been set up correctly
+#[tokio::test]
+async fn ensure_prompting_is_enabled() -> Result<()> {
+    let c = SnapdSocketClient::default();
+    assert!(c.is_prompting_enabled().await?, "prompting is not enabled");
+
+    Ok(())
+}
+
 #[test_case(Action::Allow, "testing testing 1 2 3\n", ""; "allow")]
 #[test_case(Action::Deny, "", "cat: /home/ubuntu/test/<PATH>/test.txt: Permission denied\n"; "deny")]
 #[tokio::test]
@@ -65,27 +101,15 @@ async fn happy_path_read_single(
     expected_stdout: &str,
     expected_stderr: &str,
 ) -> Result<()> {
-    // Creating the client before spawning the test snap so that our polling `after`
-    // is correct to pick up the prompt.
     let mut c = SnapdSocketClient::default();
     let (prefix, dir_path) = setup_test_dir(None, &[("test.txt", expected_stdout)])?;
 
     let rx = spawn_for_output("aa-prompting-test.read", vec![prefix.clone()]);
+    let (id, p) = expect_single_prompt(&mut c, &format!("{dir_path}/test.txt"), &["read"]).await;
 
-    let pending = c.pending_prompts().await?;
-    assert_eq!(pending.len(), 1, "expected a single prompt");
-
-    let id = &pending[0];
-    let p = c.prompt_details(id).await?;
-
-    assert_eq!(p.snap(), TEST_SNAP);
-    assert_eq!(p.path(), format!("{dir_path}/test.txt"));
-    assert_eq!(p.requested_permissions(), &["read"]);
-
-    let reply = p.simple_reply(action, Lifespan::Single);
-    c.reply_to_prompt(id, reply).await?;
-
+    c.reply_to_prompt(&id, p.into_reply(action)).await?;
     let output = rx.recv().expect("to be able recv");
+
     assert_eq!(output.stdout, expected_stdout, "stdout");
     assert_eq!(
         output.stderr,
@@ -101,44 +125,29 @@ async fn happy_path_read_single(
 #[tokio::test]
 #[serial]
 async fn happy_path_create_multiple(action: Action) -> Result<()> {
-    // Creating the client before spawning the test snap so that our polling `after`
-    // is correct to pick up the prompt.
     let mut c = SnapdSocketClient::default();
     let (prefix, dir_path) = setup_test_dir(None, &[])?;
 
     let _rx = spawn_for_output("aa-prompting-test.create", vec![prefix]);
+    let (id, p) = expect_single_prompt(&mut c, &format!("{dir_path}/test-1.txt"), &["write"]).await;
+    let reply = p
+        .into_reply(action)
+        .for_timespan("1s")
+        .with_custom_path_pattern(format!("{dir_path}/*"));
 
-    let pending = c.pending_prompts().await?;
-    assert_eq!(pending.len(), 1, "expected a single prompt");
-
-    let id = &pending[0];
-    let p = c.prompt_details(id).await?;
-
-    let files = &[
-        ("test-1.txt", "test\n"),
-        ("test-2.txt", "test\n"),
-        ("test-3.txt", "test\n"),
-    ];
-
-    // The prompt should be for the first write we are attempting
-    assert_eq!(p.snap(), TEST_SNAP);
-    assert_eq!(p.path(), format!("{dir_path}/test-1.txt"));
-    assert_eq!(p.requested_permissions(), &["write"]);
-
-    let reply = p.build_reply(
-        action,
-        Lifespan::Timespan,
-        Some("1s"),
-        Some(format!("{dir_path}/*")),
-        None,
-    );
-    c.reply_to_prompt(id, reply).await?;
+    c.reply_to_prompt(&id, reply).await?;
 
     // We're just using the recv to wait for the test snap to finish running
     // so we don't care about the output
     // FIXME: work out why this hangs even when the test snap has output
     // _ = rx.recv().expect("to be able recv");
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let files = &[
+        ("test-1.txt", "test\n"),
+        ("test-2.txt", "test\n"),
+        ("test-3.txt", "test\n"),
+    ];
 
     for (p, s) in files {
         let res = fs::read_to_string(format!("{dir_path}/{p}"));
@@ -149,6 +158,56 @@ async fn happy_path_create_multiple(action: Action) -> Result<()> {
                 ErrorKind::NotFound
             ),
         }
+    }
+
+    Ok(())
+}
+
+// FIXME: we will want to have these errors returned in a way that allows to present a meaningful
+// error message to the user.
+#[test_case("not a valid custom path!", "invalid path pattern"; "malformed path")]
+#[test_case("/home/bob/*", "constraints in reply do not match original request"; "invalid path")]
+#[tokio::test]
+#[serial]
+async fn incorrect_custom_paths_error(reply_path: &str, expected_prefix: &str) -> Result<()> {
+    let mut c = SnapdSocketClient::default();
+    let (prefix, dir_path) = setup_test_dir(None, &[("test.txt", "test")])?;
+
+    let _rx = spawn_for_output("aa-prompting-test.read", vec![prefix]);
+    let (id, p) = expect_single_prompt(&mut c, &format!("{dir_path}/test.txt"), &["read"]).await;
+    let reply = p
+        .into_reply(Action::Allow)
+        .with_custom_path_pattern(reply_path);
+
+    match c.reply_to_prompt(&id, reply).await {
+        Err(Error::SnapdError { message }) => assert!(
+            message.starts_with(expected_prefix),
+            "message format not as expected: {message}"
+        ),
+        Err(e) => panic!("expected a snapd error, got: {e}"),
+        Ok(_) => panic!("should have errored but got an OK response"),
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn invalid_timeperiod_duration_errors() -> Result<()> {
+    let mut c = SnapdSocketClient::default();
+    let (prefix, dir_path) = setup_test_dir(None, &[("test.txt", "test")])?;
+
+    let _rx = spawn_for_output("aa-prompting-test.read", vec![prefix]);
+    let (id, p) = expect_single_prompt(&mut c, &format!("{dir_path}/test.txt"), &["read"]).await;
+    let reply = p.into_reply(Action::Allow).for_timespan("foo");
+
+    match c.reply_to_prompt(&id, reply).await {
+        Err(Error::SnapdError { message }) => assert!(
+            message.starts_with("error parsing duration string:"),
+            "message format not as expected: {message}"
+        ),
+        Err(e) => panic!("expected a snapd error, got: {e}"),
+        Ok(_) => panic!("should have errored but got an OK response"),
     }
 
     Ok(())


### PR DESCRIPTION
Some initial tests covering the error responses we expect to handle from `snapd`. We'll want to have these updated in order to support displaying user friendly error messages eventually but for now this ensures that we correctly understand the error states we need to work with.