### PR TITLE
UDENG-3253 handling errors with custom paths in the UI and client

### DIFF
--- a/aa-prompt-client/src/cli_actions/listener.rs
+++ b/aa-prompt-client/src/cli_actions/listener.rs
@@ -1,20 +1,45 @@
 use crate::{
-    snapd_client::{Action, Prompt, PromptReply, SnapdSocketClient, UiPromptReply},
-    Result,
+    snapd_client::{Action, Prompt, PromptId, PromptReply, SnapdSocketClient, UiPromptReply},
+    Error, Result,
 };
 use std::{
     env,
     io::{stdin, stdout, Write},
 };
 use tokio::process::Command;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 trait ReplyClient {
-    async fn get_reply(&self, p: Prompt) -> Result<PromptReply>;
+    async fn get_reply(&self, p: Prompt, prev_error: Option<String>) -> Result<PromptReply>;
+
+    async fn reply_retrying_errors(
+        &self,
+        c: &mut SnapdSocketClient,
+        id: PromptId,
+        p: Prompt,
+    ) -> Result<()> {
+        let mut reply = self.get_reply(p.clone(), None).await?;
+
+        debug!(?id, ?reply, "replying to prompt");
+        while let Err(e) = c.reply_to_prompt(&id, reply).await {
+            let prev_error = match e {
+                Error::SnapdError { message } => message,
+                _ => {
+                    error!(%e, "unexpected error in replying to prompt");
+                    return Err(e);
+                }
+            };
+
+            debug!(%prev_error, "error returned from snapd, retrying");
+            reply = self.get_reply(p.clone(), Some(prev_error)).await?;
+            debug!(?id, ?reply, "replying to prompt");
+        }
+
+        Ok(())
+    }
 }
 
-/// This is a bare bones client implementation that only supports responding to prompts
-/// with "allow single" or "deny single".
+/// Run a simple client listener that processes notices and prompts serially
 async fn run_client_loop<C: ReplyClient>(mut c: SnapdSocketClient, client: C) -> Result<()> {
     loop {
         println!("polling for notices...");
@@ -31,12 +56,7 @@ async fn run_client_loop<C: ReplyClient>(mut c: SnapdSocketClient, client: C) ->
                 }
             };
 
-            let reply = client.get_reply(p).await?;
-
-            debug!(?id, ?reply, "replying to prompt");
-            if let Err(e) = c.reply_to_prompt(&id, reply).await {
-                warn!(%e, "error in replying to prompt");
-            }
+            client.reply_retrying_errors(&mut c, id, p).await?;
         }
     }
 }
@@ -60,17 +80,24 @@ impl FlutterClient {
 }
 
 impl ReplyClient for FlutterClient {
-    async fn get_reply(&self, p: Prompt) -> Result<PromptReply> {
-        let input = serde_json::to_string(&p.as_ui_prompt_input())?;
+    async fn get_reply(&self, p: Prompt, prev_error: Option<String>) -> Result<PromptReply> {
+        let input = serde_json::to_string(&p.as_ui_prompt_input(prev_error))?;
         debug!(input, "prompt details for the flutter ui");
 
-        let output = Command::new(&self.cmd).arg(input).output().await?;
-        debug!(
-            raw_stdout = %String::from_utf8(output.stdout.clone()).unwrap(),
-            "raw output from the flutter ui"
-        );
+        // If the user closes out the prompt without submitting a reply we will get nothing on
+        // stdout so we retry until they action the prompt in order to not leave the snap that
+        // generated the prompt in a hung state.
+        let mut stdout = Vec::new();
+        while stdout.is_empty() {
+            let output = Command::new(&self.cmd).arg(&input).output().await?;
+            debug!(
+                raw_stdout = %String::from_utf8(output.stdout.clone()).unwrap(),
+                "raw output from the flutter ui"
+            );
+            stdout = output.stdout
+        }
 
-        let ui_reply: UiPromptReply = serde_json::from_slice(&output.stdout)?;
+        let ui_reply: UiPromptReply = serde_json::from_slice(&stdout)?;
         debug!(?ui_reply, "parsed reply from the flutter ui");
 
         Ok(p.into_reply_from_ui(ui_reply))
@@ -86,7 +113,7 @@ pub async fn run_terminal_client_loop(c: SnapdSocketClient) -> Result<()> {
 struct TerminalClient;
 
 impl ReplyClient for TerminalClient {
-    async fn get_reply(&self, p: Prompt) -> Result<PromptReply> {
+    async fn get_reply(&self, p: Prompt, _: Option<String>) -> Result<PromptReply> {
         let summary = format!(
             "\
 id:          {}

--- a/aa-prompt-client/src/snapd_client.rs
+++ b/aa-prompt-client/src/snapd_client.rs
@@ -294,7 +294,7 @@ impl Prompt {
         }
     }
 
-    pub fn as_ui_prompt_input(&self) -> UiPromptInput {
+    pub fn as_ui_prompt_input(&self, previous_error_message: Option<String>) -> UiPromptInput {
         let requested_path = self.constraints.path.clone();
         let parent_directory = PathBuf::from(&requested_path)
             .parent()
@@ -307,6 +307,7 @@ impl Prompt {
             parent_directory,
             requested_permissions: self.constraints.permissions.clone(),
             available_permissions: self.constraints.available_permissions.clone(),
+            previous_error_message,
         }
     }
 }
@@ -319,6 +320,7 @@ pub struct UiPromptInput {
     parent_directory: String,
     requested_permissions: Vec<String>,
     available_permissions: Vec<String>,
+    previous_error_message: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/apparmor_prompt/lib/prompt_data_model.dart
+++ b/apparmor_prompt/lib/prompt_data_model.dart
@@ -26,6 +26,7 @@ class PromptDetails with _$PromptDetails {
     required String parentDirectory,
     required List<Permission> requestedPermissions,
     required List<Permission> availablePermissions,
+    String? previousErrorMessage,
   }) = _PromptDetails;
 
   factory PromptDetails.fromJson(Map<String, dynamic> json) =>
@@ -42,7 +43,6 @@ class PromptData with _$PromptData {
     PermissionChoice? permissionChoice,
     AccessPolicy? accessPolicy,
     Lifespan? lifespan,
-    String? previousErrorMessage,
   }) = _PromptData;
 
   PromptData._();
@@ -69,11 +69,14 @@ class PromptDataModel extends _$PromptDataModel {
   @override
   PromptData build() {
     final details = getService<PromptDetails>();
+    final inErrorState = details.previousErrorMessage != null;
 
     return PromptData(
       details: details,
-      withMoreOptions: false,
-      permissionChoice: PermissionChoice.requested,
+      withMoreOptions: inErrorState,
+      permissionChoice: inErrorState
+          ? PermissionChoice.customPath
+          : PermissionChoice.requested,
       accessPolicy: AccessPolicy.allow,
       lifespan: Lifespan.forever,
       permissions: details.requestedPermissions,

--- a/apparmor_prompt/lib/prompt_page.dart
+++ b/apparmor_prompt/lib/prompt_page.dart
@@ -209,7 +209,7 @@ class AccessToggle extends ConsumerWidget {
             initialValue: model.details.parentDirectory,
             onChanged: notifier.setCustomPath,
             decoration: InputDecoration(
-              errorText: model.previousErrorMessage,
+              errorText: model.details.previousErrorMessage,
             ),
           ),
           const Text('<Learn about path patterns>'),


### PR DESCRIPTION
This ensures that we show any error message associated with a malformed custom path on startup and that the generating errors results in an automatic retry. The error handling around the user closing out the prompt without replying is _better_ (good enough for initial internal testing) but there are quite a few places where I'm using `?` still that can result with the client loop erroring out and newly generated prompts getting dropped on the floor. This isn't OK for the final thing but for now it's alright and lets us get going with user testing.

I still need to update the README / write a doc on how to test and report issues for people to take a look at but I'll tackle that tomorrow.


https://github.com/canonical/aa-prompting-test/assets/8116092/6100df75-fd06-4696-93fc-1008a1362dd2

