### PR TITLE
UDENG-3253 supporting recording prompts from within the snap package

### DIFF
--- a/aa-prompt-client/src/cli_actions/echo_loop.rs
+++ b/aa-prompt-client/src/cli_actions/echo_loop.rs
@@ -1,19 +1,79 @@
-use crate::{snapd_client::SnapdSocketClient, Result};
-use std::fs;
+use crate::{
+    snapd_client::{Action, Prompt, SnapdSocketClient},
+    Result,
+};
+use serde::{Deserialize, Serialize};
+use std::{fs, process::exit};
 use tokio::{select, signal::ctrl_c};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
+
+const SNAP_NAME: &str = "apparmor-prompting";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PromptRecording {
+    version: u8, // currently only v1
+    prompts: Vec<Prompt>,
+}
+
+impl PromptRecording {
+    pub fn new() -> Self {
+        Self {
+            version: 1,
+            prompts: Vec::new(),
+        }
+    }
+}
 
 pub async fn run_echo_loop(mut c: SnapdSocketClient, path: Option<String>) -> Result<()> {
-    let recording = path.is_some();
-    let mut prompts = Vec::new();
+    let recording_prompts = match &path {
+        Some(path) => {
+            info!(%path, "recording enabled: triggering prompt for later creation of output file");
+            let path = path.clone();
+            // We need to make use of the home interface ourselves in order to be able to create
+            // our output file when recording, so we listen for and allow the creation of the
+            // recording file on startup.
+            tokio::task::spawn(async move {
+                // @olivercalder these are the back to back writes that result in the file being
+                // truncated but not written to. Also see the integration test that has been added
+                // around overwriting an existing file for the behaviour observed from the shell:
+                //   printf "%s" "$content" > "$FILE_PATH"
+                //
+                // Source for 'fs::write': https://doc.rust-lang.org/src/std/fs.rs.html#339-344
+                // Source for 'File::create': https://doc.rust-lang.org/src/std/fs.rs.html#403-405
+                debug!(%path, "creating output file");
+                match fs::write(&path, "1") {
+                    Ok(_) => debug!("output file created"),
+                    Err(e) => {
+                        error!(%e, "unable to create output file");
+                        exit(1);
+                    }
+                }
+                match fs::write(&path, "2") {
+                    Ok(_) => debug!("output file created"),
+                    Err(e) => {
+                        error!(%e, "unable to create output file");
+                        exit(1);
+                    }
+                }
+            });
+
+            true
+        }
+
+        None => false,
+    };
+
+    let mut rec = PromptRecording::new();
 
     loop {
         debug!("waiting for notices");
         let pending = select! {
             res = c.pending_prompts() => res?,
             _ = ctrl_c() => {
-                if recording {
-                    fs::write(path.unwrap(), serde_json::to_string(&prompts)?)?;
+                if recording_prompts && !rec.prompts.is_empty() {
+                    let path = path.unwrap();
+                    info!(n=%rec.prompts.len(), %path, "writing prompts to file");
+                    fs::write(path, serde_json::to_string(&rec)?)?;
                 }
 
                 return Ok(());
@@ -23,17 +83,28 @@ pub async fn run_echo_loop(mut c: SnapdSocketClient, path: Option<String>) -> Re
         info!(?pending, "processing notices");
         for id in pending {
             debug!(?id, "pulling prompt details from snapd");
-            let p = match c.prompt_details(&id).await {
-                Ok(p) => p,
-                Err(e) => {
-                    warn!(%e, "unable to pull prompt");
-                    continue;
+            match c.prompt_details(&id).await {
+                Ok(p) if p.snap() == SNAP_NAME => {
+                    let id = p.id.clone();
+                    let reply = p
+                        .into_reply(Action::Allow)
+                        .for_forever()
+                        .try_with_custom_permissions(vec![
+                            "read".to_string(),
+                            "write".to_string(),
+                        ])?;
+                    info!("auto-replying to our own prompt for creating output file");
+                    c.reply_to_prompt(&id, reply).await?;
                 }
-            };
 
-            println!("{}", serde_json::to_string(&p)?);
-            if recording {
-                prompts.push(p);
+                Ok(p) => {
+                    println!("{}", serde_json::to_string(&p)?);
+                    if recording_prompts {
+                        rec.prompts.push(p);
+                    }
+                }
+
+                Err(e) => warn!(%e, "unable to pull prompt"),
             }
         }
     }

--- a/aa-prompt-client/tests/integration.rs
+++ b/aa-prompt-client/tests/integration.rs
@@ -248,3 +248,44 @@ async fn invalid_timeperiod_duration_errors() -> Result<()> {
 
     Ok(())
 }
+
+// @olivercalder This failing test case shows a third unexpected behaviour, namely that the script
+// in the snap does not error but the write does not take place...
+// To get the truncation behaviour you will need to run the echo command of the client with verbose
+// logging enabled and then check the resulting logs.
+#[tokio::test]
+#[serial]
+async fn overwriting_a_file_works() -> Result<()> {
+    let mut c = SnapdSocketClient::default();
+    let (prefix, dir_path) = setup_test_dir(None, &[])?;
+
+    let rx = spawn_for_output(
+        "aa-prompting-test.create-single",
+        vec![prefix.clone(), "before".to_string()],
+    );
+    let (id, p) = expect_single_prompt(&mut c, &format!("{dir_path}/test.txt"), &["write"]).await;
+
+    let reply = p.into_reply(Action::Allow).for_forever();
+    c.reply_to_prompt(&id, reply).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // The file should have been created and contain the correct content
+    let res = fs::read_to_string(format!("{dir_path}/test.txt"));
+    assert_eq!(res.expect("file should exist"), "before");
+
+    // Not expecting another prompt due to previous allow always reply
+    let _rx = spawn_for_output(
+        "aa-prompting-test.create-single",
+        vec![prefix, "after".to_string()],
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    let output = rx.recv().expect("to be able recv");
+    assert_eq!(output.stdout, "done\n");
+    assert_eq!(output.stderr, "");
+
+    // The file should now contain the updated content
+    let res = fs::read_to_string(format!("{dir_path}/test.txt"));
+    assert_eq!(res.expect("file should exist"), "after");
+
+    Ok(())
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ apps:
     extensions: [gnome]
     plugs:
       - snap-prompting-control
+      - home
 
 parts:
   flutter-git:

--- a/testing-snap/scripts/create-nested.sh
+++ b/testing-snap/scripts/create-nested.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-prefix="$1"
-
-printf "test\n" > "${SNAP_REAL_HOME}/test/${prefix}/nested/test.txt"

--- a/testing-snap/scripts/create-single.sh
+++ b/testing-snap/scripts/create-single.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -e
+
+prefix="$1"
+content="$2"
+
+printf "%s" "$content" > "${SNAP_REAL_HOME}/test/${prefix}/test.txt"
+echo "done"

--- a/testing-snap/scripts/read-nested.sh
+++ b/testing-snap/scripts/read-nested.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-prefix="$1"
-
-cat "${SNAP_REAL_HOME}/test/${prefix}/nested/test.txt"

--- a/testing-snap/snap/snapcraft.yaml
+++ b/testing-snap/snap/snapcraft.yaml
@@ -19,15 +19,11 @@ apps:
     command: ./read.sh
     plugs:
       - home
-  read-nested:
-    command: ./read-nested.sh
-    plugs:
-      - home
   create:
     command: ./create.sh
     plugs:
       - home
-  create-nested:
-    command: ./create-nested.sh
+  create-single:
+    command: ./create-single.sh
     plugs:
       - home


### PR DESCRIPTION
Attempt at sorting out recording prompts from inside of a snap that has lead to finding a bug around overwriting files. Details are captured [here](https://warthogs.atlassian.net/browse/SNAPDENG-23750) and while I _think_ it should be doable to get this working without waiting for a fix, the resulting code would be a lot more convoluted and leaving this blocked acts as a good reminder to chase things up :wink: 