### PR TITLE
test(aa-prompt): add integration test that runs the UI in dry-run mode

### DIFF
--- a/.github/workflows/flutter.yaml
+++ b/.github/workflows/flutter.yaml
@@ -52,6 +52,26 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
 
+  apparmor-prompt:
+    needs: analyze
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: asdf-vm/actions/install@v2
+      - uses: bluefireteam/melos-action@v2
+      - uses: actions/cache@v3
+        with:
+          path: |
+            flutter_packages/**/*.freezed.dart
+            flutter_packages/**/*.g.dart
+            flutter_packages/**/*.mocks.dart
+          key: melos-generate-${{ github.sha }}
+      - run: |
+          sudo apt update
+          sudo apt install -y clang cmake libglib2.0-dev libgtk-3-dev liblzma-dev ninja-build pkg-config xvfb
+          cd flutter_packages/apparmor_prompt
+          xvfb-run -a -s '-screen 0 1024x768x24 +extension GLX' flutter test integration_test
+
   security-center:
     needs: analyze
     runs-on: ubuntu-22.04

--- a/flutter_packages/apparmor_prompt/integration_test/apparmor_prompt_test.dart
+++ b/flutter_packages/apparmor_prompt/integration_test/apparmor_prompt_test.dart
@@ -1,0 +1,66 @@
+import 'package:apparmor_prompt/fake_apparmor_prompting_client.dart';
+import 'package:apparmor_prompt/l10n_x.dart';
+import 'package:apparmor_prompt/main.dart' as app;
+import 'package:apparmor_prompting_client/apparmor_prompting_client.dart';
+import 'package:flutter/material.dart' hide Action;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:yaru_test/yaru_test.dart';
+
+import '../test/test_utils.dart';
+
+void main() {
+  tearDown(resetAllServices);
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  YaruTestWindow.ensureInitialized();
+
+  testWidgets('UI dry-run', (tester) async {
+    await app.main(['--dry-run']);
+    await tester.pumpAndSettle();
+
+    final fakeApparmorPromptingClient =
+        getService<AppArmorPromptingClient>() as FakeApparmorPromptingClient;
+    fakeApparmorPromptingClient.onReply = (reply) => expect(
+          reply,
+          PromptReply.home(
+            promptId: 'promptId',
+            action: Action.deny,
+            lifespan: Lifespan.session,
+            pathPattern: '/home/ubuntu/**/',
+            permissions: [
+              Permission.write,
+              Permission.execute,
+            ],
+          ),
+        );
+
+    // Expand metadata section
+    await tester.tap(find.text(tester.l10n.homePromptMetaDataTitle));
+    await tester.pumpAndSettle();
+    expect(
+      find.text(tester.l10n.homePromptMetaDataPublishedBy('Mozilla')),
+      findsOneWidget,
+    );
+
+    // Select 'custom prompt' to reveal text field
+    await tester
+        .tap(find.text(HomePatternType.customPath.localize(tester.l10n)));
+    await tester.pumpAndSettle();
+
+    // Enter custom path
+    await tester.enterText(find.byType(TextField), '/home/ubuntu/**/');
+
+    // Select action and lifespan
+    await tester.tap(find.text(Action.deny.localize(tester.l10n)));
+    await tester.tap(find.text(Lifespan.session.localize(tester.l10n)));
+
+    // De-select 'read' permission, select 'write' permission
+    await tester.tap(find.text(Permission.read.localize(tester.l10n)));
+    await tester.tap(find.text(Permission.execute.localize(tester.l10n)));
+
+    // Save and continue
+    await tester.tap(find.text(tester.l10n.promptSaveAndContinue));
+    await tester.pumpAndSettle();
+  });
+}

--- a/flutter_packages/apparmor_prompt/lib/fake_apparmor_prompting_client.dart
+++ b/flutter_packages/apparmor_prompt/lib/fake_apparmor_prompting_client.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:apparmor_prompting_client/apparmor_prompting_client.dart';
+import 'package:flutter/foundation.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
 final _log = Logger('fake_apparmor_prompting_client');
@@ -16,12 +17,16 @@ class FakeApparmorPromptingClient implements AppArmorPromptingClient {
   }
   final PromptDetails currentPrompt;
 
+  @visibleForTesting
+  void Function(PromptReply reply)? onReply;
+
   @override
   Future<PromptDetails> getCurrentPrompt() async => currentPrompt;
 
   @override
   Future<PromptReplyResponse> replyToPrompt(PromptReply reply) async {
     _log.info('replyToPrompt: $reply');
+    onReply?.call(reply);
     // This regex checks whether the provided path starts with a `/` and does
     // not contain any `[` or `]` characters. (Same check that snapd does
     // internally)

--- a/flutter_packages/apparmor_prompt/lib/main.dart
+++ b/flutter_packages/apparmor_prompt/lib/main.dart
@@ -13,7 +13,7 @@ import 'package:yaru/yaru.dart';
 
 const envVarSocketPath = 'AA_PROMPTING_CLIENT_SOCKET';
 
-void main(List<String> args) async {
+Future<void> main(List<String> args) async {
   // We specify path as an empty string in order to get ubuntu_logger to skip
   // setting up a file for logging
   Logger.setup(path: '', level: LogLevel.info);

--- a/flutter_packages/apparmor_prompt/lib/test_prompt_details.json
+++ b/flutter_packages/apparmor_prompt/lib/test_prompt_details.json
@@ -4,7 +4,7 @@
         "promptId": "promptId",
         "snapName": "firefox",
         "updatedAt": "2024-07-13T10:57:28.34963269+02:00",
-        "storeUrl": "storeUrl",
+        "storeUrl": "snap://firefox",
         "publisher": "Mozilla"
     },
     "requestedPath": "/home/ubuntu/Downloads/file.txt",

--- a/flutter_packages/apparmor_prompt/pubspec.lock
+++ b/flutter_packages/apparmor_prompt/pubspec.lock
@@ -269,6 +269,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: transitive
     description:
@@ -332,6 +337,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   get_it:
     dependency: transitive
     description:
@@ -428,6 +438,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -600,10 +615,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.4"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -620,6 +635,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   protobuf:
     dependency: transitive
     description:
@@ -769,6 +792,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -945,6 +976,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
   window_manager:
     dependency: transitive
     description:

--- a/flutter_packages/apparmor_prompt/pubspec.yaml
+++ b/flutter_packages/apparmor_prompt/pubspec.yaml
@@ -32,6 +32,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ^2.5.2
+  integration_test:
+    sdk: flutter
   mockito: ^5.4.4
   riverpod_generator: ^2.4.0
   yaru_test: ^0.1.6


### PR DESCRIPTION
Adds a simple integration test that runs the prompt UI with the `--dry-run` flag, displaying the test prompt from `test_prompt_details.json`. It interacts with all the UI elements and verifies the correct reply is sent back to the fake service.

UDENG-3461