### PR TITLE
refactor: adding more logging and refactoring server

### DIFF
--- a/flutter_packages/prompting_client/lib/src/generated/apparmor-prompting.pbenum.dart
+++ b/flutter_packages/prompting_client/lib/src/generated/apparmor-prompting.pbenum.dart
@@ -79,10 +79,12 @@ class HomePatternType extends $pb.ProtobufEnum {
 class PromptReplyResponse_PromptReplyType extends $pb.ProtobufEnum {
   static const PromptReplyResponse_PromptReplyType SUCCESS = PromptReplyResponse_PromptReplyType._(0, _omitEnumNames ? '' : 'SUCCESS');
   static const PromptReplyResponse_PromptReplyType UNKNOWN = PromptReplyResponse_PromptReplyType._(1, _omitEnumNames ? '' : 'UNKNOWN');
+  static const PromptReplyResponse_PromptReplyType PROMPT_NOT_FOUND = PromptReplyResponse_PromptReplyType._(2, _omitEnumNames ? '' : 'PROMPT_NOT_FOUND');
 
   static const $core.List<PromptReplyResponse_PromptReplyType> values = <PromptReplyResponse_PromptReplyType> [
     SUCCESS,
     UNKNOWN,
+    PROMPT_NOT_FOUND,
   ];
 
   static final $core.Map<$core.int, PromptReplyResponse_PromptReplyType> _byValue = $pb.ProtobufEnum.initByValue(values);

--- a/flutter_packages/prompting_client/lib/src/generated/apparmor-prompting.pbjson.dart
+++ b/flutter_packages/prompting_client/lib/src/generated/apparmor-prompting.pbjson.dart
@@ -103,6 +103,7 @@ const PromptReplyResponse_PromptReplyType$json = {
   '2': [
     {'1': 'SUCCESS', '2': 0},
     {'1': 'UNKNOWN', '2': 1},
+    {'1': 'PROMPT_NOT_FOUND', '2': 2},
   ],
 };
 
@@ -110,8 +111,8 @@ const PromptReplyResponse_PromptReplyType$json = {
 final $typed_data.Uint8List promptReplyResponseDescriptor = $convert.base64Decode(
     'ChNQcm9tcHRSZXBseVJlc3BvbnNlEmMKEXByb21wdF9yZXBseV90eXBlGAEgASgOMjcuYXBwYX'
     'Jtb3JfcHJvbXB0aW5nLlByb21wdFJlcGx5UmVzcG9uc2UuUHJvbXB0UmVwbHlUeXBlUg9wcm9t'
-    'cHRSZXBseVR5cGUSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZSIrCg9Qcm9tcHRSZXBseVR5cG'
-    'USCwoHU1VDQ0VTUxAAEgsKB1VOS05PV04QAQ==');
+    'cHRSZXBseVR5cGUSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZSJBCg9Qcm9tcHRSZXBseVR5cG'
+    'USCwoHU1VDQ0VTUxAAEgsKB1VOS05PV04QARIUChBQUk9NUFRfTk9UX0ZPVU5EEAI=');
 
 @$core.Deprecated('Use getCurrentPromptResponseDescriptor instead')
 const GetCurrentPromptResponse$json = {

--- a/prompting-client/src/bin/daemon.rs
+++ b/prompting-client/src/bin/daemon.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::{layer::SubscriberExt, FmtSubscriber};
 #[tokio::main]
 async fn main() -> Result<()> {
     let builder = FmtSubscriber::builder()
-        .with_env_filter("info")
+        .with_env_filter("debug,hyper=error,h2=error")
         .with_writer(stdout)
         .with_filter_reloading();
 

--- a/prompting-client/src/protos/apparmor_prompting.rs
+++ b/prompting-client/src/protos/apparmor_prompting.rs
@@ -45,6 +45,7 @@ pub mod prompt_reply_response {
     pub enum PromptReplyType {
         Success = 0,
         Unknown = 1,
+        PromptNotFound = 2,
     }
     impl PromptReplyType {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -55,6 +56,7 @@ pub mod prompt_reply_response {
             match self {
                 PromptReplyType::Success => "SUCCESS",
                 PromptReplyType::Unknown => "UNKNOWN",
+                PromptReplyType::PromptNotFound => "PROMPT_NOT_FOUND",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -62,6 +64,7 @@ pub mod prompt_reply_response {
             match value {
                 "SUCCESS" => Some(Self::Success),
                 "UNKNOWN" => Some(Self::Unknown),
+                "PROMPT_NOT_FOUND" => Some(Self::PromptNotFound),
                 _ => None,
             }
         }

--- a/prompting-client/src/snapd_client/mod.rs
+++ b/prompting-client/src/snapd_client/mod.rs
@@ -164,6 +164,8 @@ where
             n.last_occurred.clone_into(&mut self.notices_after);
         }
 
+        debug!("received notices: {notices:?}");
+
         return Ok(notices.into_iter().map(|n| n.key).collect());
 
         // serde structs
@@ -173,6 +175,9 @@ where
         struct Notice {
             key: PromptId,
             last_occurred: String,
+            #[allow(dead_code)]
+            #[serde(flatten)]
+            extra: HashMap<String, serde_json::Value>,
         }
     }
 

--- a/protos/apparmor-prompting.proto
+++ b/protos/apparmor-prompting.proto
@@ -26,6 +26,7 @@ message PromptReplyResponse {
     enum PromptReplyType {
         SUCCESS = 0;
         UNKNOWN = 1;
+        PROMPT_NOT_FOUND = 2;
     }
 }
 


### PR DESCRIPTION
Initially this was just some additional logging and refactoring to support looking into this issue we have observed around prompts being timed out and auto-denied (see example output below), but it ended up with a few pieces of additional cleanup after I realised that the new server tests were leaving sockets behind in `/tmp`.

@matthew-hagemann this also includes the change for reporting that a prompt has already been actioned that I mentioned to you :wink: 


### Example logs
```
ubuntu@aa-testing:~$ journalctl --user -t prompting-client-daemon --follow
Jul 26 11:27:30 aa-testing prompting-client-daemon[19793]: spawning poll loop
Jul 26 11:27:30 aa-testing prompting-client-daemon[19793]: spawning worker thread
Jul 26 11:27:30 aa-testing prompting-client-daemon[19793]: serving incoming grpc connections
Jul 26 11:27:30 aa-testing prompting-client-daemon[19793]: checking for pending prompts
Jul 26 11:27:30 aa-testing prompting-client-daemon[19793]: no currently pending prompts
Jul 26 11:27:30 aa-testing prompting-client-daemon[19793]: polling for notices
Jul 26 12:03:33 aa-testing prompting-client-daemon[19793]: received notices: [Notice { key: PromptId("C7S4DNDEEPD32==="), last_occurred: "2024-07-26T12:03:33.057426249Z", extra: {"id": String("3176"), "occurrences": Number(1), "type": String("interfaces-requests-prompt"), "first-occurred": String("2024-07-26T12:03:33.057426249Z"), "expire-after": String("168h0m0s"), "user-id": Number(1000), "last-repeated": String("2024-07-26T12:03:33.057426249Z")} }]
Jul 26 12:03:33 aa-testing prompting-client-daemon[19793]: processing notices
Jul 26 12:03:33 aa-testing prompting-client-daemon[19793]: pulling prompt details from snapd
Jul 26 12:03:33 aa-testing prompting-client-daemon[19793]: prompt details: Home(Prompt { id: PromptId("C7S4DNDEEPD32==="), timestamp: "2024-07-26T12:03:33.057423293Z", snap: "firefox", interface: "home", constraints: HomeConstraints { path: "/home/ubuntu/Downloads/test.jpeg", permissions: ["write"], available_permissions: ["read", "write", "execute"] } })
Jul 26 12:03:33 aa-testing prompting-client-daemon[19793]: polling for notices
Jul 26 12:03:33 aa-testing prompting-client-daemon[19793]: got prompt: EnrichedPrompt { prompt: Home(Prompt { id: PromptId("C7S4DNDEEPD32==="), timestamp: "2024-07-26T12:03:33.057423293Z", snap: "firefox", interface: "home", constraints: HomeConstraints { path: "/home/ubuntu/Downloads/test.jpeg", permissions: ["write"], available_permissions: ["read", "write", "execute"] } }), meta: Some(SnapMeta { name: "firefox", updated_at: "2024-07-24", store_url: "snap://firefox", publisher: "Mozilla" }) }
Jul 26 12:03:33 aa-testing prompting-client-daemon[19793]: updating active prompt
Jul 26 12:03:33 aa-testing prompting-client-daemon[19793]: spawning UI
Jul 26 13:03:33 aa-testing prompting-client-daemon[19793]: received notices: []     <-- This is then me leaving the prompt open and the long poll hitting its timeout
Jul 26 13:03:33 aa-testing prompting-client-daemon[19793]: processing notices
Jul 26 13:03:33 aa-testing prompting-client-daemon[19793]: polling for notices
Jul 26 14:03:33 aa-testing prompting-client-daemon[19793]: received notices: []
Jul 26 14:03:33 aa-testing prompting-client-daemon[19793]: processing notices
Jul 26 14:03:33 aa-testing prompting-client-daemon[19793]: polling for notices
Jul 26 14:14:13 aa-testing prompting-client-daemon[19793]: timeout waiting for ack from grpc server  <-- Force closing the prompt
Jul 26 14:14:13 aa-testing prompting-client-daemon[19793]: clearing active prompt
````