### PR TITLE
fix: increase unknown prompt id to avoid test failures on dirty system

### DIFF
--- a/prompting-client/tests/integration.rs
+++ b/prompting-client/tests/integration.rs
@@ -251,7 +251,7 @@ async fn create_multiple_actioned_by_other_pid(action: Action, lifespan: Lifespa
 #[serial]
 async fn requesting_an_unknown_prompt_id_is_an_error() -> Result<()> {
     let c = SnapdSocketClient::default();
-    let res = c.prompt_details(&PromptId("42".to_string())).await;
+    let res = c.prompt_details(&PromptId("0123456789ABCDEF".to_string())).await;
 
     match res {
         Err(Error::SnapdError { message }) => {


### PR DESCRIPTION
On my test VM, if I re-ran the integration tests multiple times, I ended up with a prompt which happened to have ID 42, causing the `requesting_an_unknown_prompt_id_is_an_error` test to fail. This PR bumps the ID to a larger number which should never reasonably conflict with a prompt ID on the system.