### PR TITLE
fix: use snapd edge at all times

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup snapd and snaps
         run: |
-          sudo snap refresh snapd --channel=latest/edge/prompting
+          sudo snap refresh snapd --channel=latest/edge
           sudo snap set system experimental.user-daemons=true
           sudo snap install --dangerous ${{ steps.snapcraft-client.outputs.snap }}
           sudo snap install --dangerous ${{ steps.snapcraft-testing.outputs.snap }}

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,12 @@ install-local-tooling:
 		apt install virt-viewer ; \
 	fi
 
-.PHONY: snapd-prompting
-snapd-prompting:
-	lxc exec $(VM_NAME) -- snap refresh snapd --channel=latest/edge/prompting; \
+.PHONY: enable-prompting
+enable-prompting:
 	lxc exec $(VM_NAME) -- snap set system experimental.apparmor-prompting=true
 
-.PHONY: snapd-edge
-snapd-edge:
-	lxc exec $(VM_NAME) -- snap refresh snapd --channel=latest/edge; \
+.PHONY: disable-prompting
+disable-prompting:
 	lxc exec $(VM_NAME) -- snap set system experimental.apparmor-prompting=false
 
 .PHONY: clean-request-rules
@@ -45,7 +43,7 @@ clean-request-rules:
 # for prompts. There is probably a lighter touch way of getting things working again
 # but this does the trick.
 .PHONY: bounce-snapd
-bounce-snapd: snapd-edge clean-request-rules snapd-prompting
+bounce-snapd: disable-prompting clean-request-rules enable-prompting
 
 .PHONY: create-or-start-vm
 create-or-start-vm:
@@ -153,14 +151,12 @@ clean:
 
 # Targets for local use rather than against the VM
 
-.PHONY: local-snapd-prompting
-local-snapd-prompting:
-	snap refresh snapd --channel=latest/edge/prompting; \
+.PHONY: local-enable-prompting
+local-enable-prompting:
 	snap set system experimental.apparmor-prompting=true
 
-.PHONY: local-snapd-edge
-local-snapd-edge:
-	snap refresh snapd --channel=latest/edge; \
+.PHONY: local-disable-prompting
+local-disable-prompting:
 	snap set system experimental.apparmor-prompting=false
 
 .PHONY: local-clean-request-rules
@@ -170,7 +166,7 @@ local-clean-request-rules:
 	fi
 
 .PHONY: local-bounce-snapd
-local-bounce-snapd: local-snapd-edge local-clean-request-rules local-snapd-prompting
+local-bounce-snapd: local-disable-prompting local-clean-request-rules local-enable-prompting
 
 .PHONY: local-install-client
 local-install-client:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ observed from snaps when running under apparmor prompting
 ### Running in a lxd VM (Recommended)
 
 So long as you have `lxd` installed you will be able to quickly spin up and
-bootstrap a VM for local testing against the `latest/edge/prompting` channel
+bootstrap a VM for local testing against the `latest/edge` channel
 of snapd.
 
 > If you have your own preferred workflow for local development and testing
@@ -93,7 +93,7 @@ $ make integration-tests
 
 This test suite is not intended for full coverage of the API interactions
 between the client and snapd, but it should be sufficient to check and validate
-the behaviour of the client against the most recent `latest/edge/prompting`
+the behaviour of the client against the most recent `latest/edge`
 channel of snapd.
 
 


### PR DESCRIPTION
Now that all of the outstanding prompting work has landed in snapd master, the client can use snapd latest/edge for all testing, and the latest/edge/prompting branch will be deprecated.

In the future, after snapd 2.65 becomes stable, the client can switch to using latest/stable, if desired.