### PR TITLE
fix(integration_test): ensure prompting-client is installed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,7 @@ jobs:
           sudo apt update
           sudo apt install -y clang cmake libglib2.0-dev libgtk-3-dev liblzma-dev ninja-build pkg-config polkitd xvfb
           sudo snap refresh snapd --channel=latest/edge/prompting
+          sudo snap install --edge prompting-client
           sudo snap set system experimental.apparmor-prompting=true
           sudo cp integration_test/assets/snapd-ci.pkla /var/lib/polkit-1/localauthority/50-local.d/
           xvfb-run -a -s '-screen 0 1024x768x24 +extension GLX' flutter test integration_test


### PR DESCRIPTION
snapd from the prompting channel now requires a prompting client to be present before the feature can be enabled