### PR TITLE
feat(prompting_ui): add libhandy for rounded corners

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.22.2-stable
+flutter 3.19.6-stable

--- a/flutter_packages/prompting_client/pubspec.yaml
+++ b/flutter_packages/prompting_client/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: ^3.4.3
+  sdk: ">=3.3.3 <4.0.0"
 
 dependencies:
   freezed_annotation: ^2.4.4
@@ -13,8 +13,8 @@ dependencies:
   protobuf: ^3.1.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
-  freezed: ^2.5.7
+  build_runner: ^2.4.9
+  freezed: ^2.5.2
   json_serializable: ^6.8.0
   mockito: ^5.4.4
   test: ^1.24.0

--- a/flutter_packages/prompting_client_ui/linux/flutter/generated_plugin_registrant.cc
+++ b/flutter_packages/prompting_client_ui/linux/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <gtk/gtk_plugin.h>
+#include <handy_window/handy_window_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
@@ -16,6 +17,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
+  g_autoptr(FlPluginRegistrar) handy_window_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "HandyWindowPlugin");
+  handy_window_plugin_register_with_registrar(handy_window_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
   screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);

--- a/flutter_packages/prompting_client_ui/linux/flutter/generated_plugins.cmake
+++ b/flutter_packages/prompting_client_ui/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   gtk
+  handy_window
   screen_retriever
   url_launcher_linux
   window_manager

--- a/flutter_packages/prompting_client_ui/linux/my_application.cc
+++ b/flutter_packages/prompting_client_ui/linux/my_application.cc
@@ -48,16 +48,16 @@ static void my_application_activate(GApplication* application) {
   }
 
   gtk_window_set_default_size(window, 560, 200);
-  gtk_widget_show(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);
 
   FlView* view = fl_view_new(project);
-  gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+  gtk_widget_show(GTK_WIDGET(window));
+  gtk_widget_show(GTK_WIDGET(view));
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }

--- a/flutter_packages/prompting_client_ui/pubspec.lock
+++ b/flutter_packages/prompting_client_ui/pubspec.lock
@@ -399,6 +399,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  handy_window:
+    dependency: "direct main"
+    description:
+      name: handy_window
+      sha256: "56b813e58a68b0ee2ab22051400b8b1f1b5cfe88b8cd32288623defb3926245a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   http:
     dependency: transitive
     description:

--- a/flutter_packages/prompting_client_ui/pubspec.lock
+++ b/flutter_packages/prompting_client_ui/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
+      sha256: "0343061a33da9c5810b2d6cee51945127d8f4c060b7fbdd9d54917f0a3feaaa1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.1"
   build_resolvers:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
+      sha256: "3ac61a79bfb6f6cc11f693591063a7f19a7af628dc52f141743edac5c16e8c22"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.11"
+    version: "2.4.9"
   build_runner_core:
     dependency: transitive
     description:
@@ -221,10 +221,18 @@ packages:
     dependency: transitive
     description:
       name: dio
-      sha256: "11e40df547d418cc0c4900a9318b26304e665da6fa4755399a9ff9efd09034b5"
+      sha256: e17f6b3097b8c51b72c74c9f071a605c47bcc8893839bd66732457a5ebe73714
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.3+1"
+    version: "5.5.0+1"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "36c5b2d79eb17cdae41e974b7a8284fec631651d2a6f39a8a2ff22327e90aeac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -440,10 +448,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.18.1"
   io:
     dependency: transitive
     description:
@@ -480,26 +488,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.0"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "2.0.1"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -568,10 +576,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -735,10 +743,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "073c147238594ecd0d193f3456a5fe91c4b0abbcc68bf5cd95b36c4e194ac611"
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -828,10 +836,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.6.1"
   timing:
     dependency: transitive
     description:
@@ -860,10 +868,10 @@ packages:
     dependency: "direct main"
     description:
       name: ubuntu_localizations
-      sha256: "547fb1b865712347497bbe8c3c0018629693ca435a9a8ec92e37f9499f6235c8"
+      sha256: eca4f43453339acca16b4b23a70b93315ab92b1500f98156a8f95af5e5078def
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.6"
   ubuntu_logger:
     dependency: "direct main"
     description:
@@ -892,18 +900,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: ceb2625f0c24ade6ef6778d1de0b2e44f2db71fded235eb52295247feba8c5cf
+      sha256: "17cd5e205ea615e2c6ea7a77323a11712dffa0720a8a90540db57a01347f9ad9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "6.3.2"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "7068716403343f6ba4969b4173cbf3b84fc768042124bc2c011e5d782b24fe89"
+      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.3.1"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -940,10 +948,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
+      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   vector_math:
     dependency: transitive
     description:
@@ -956,10 +964,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:
@@ -976,22 +984,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
-  web_socket:
-    dependency: transitive
-    description:
-      name: web_socket
-      sha256: "24301d8c293ce6fe327ffe6f59d8fd8834735f0ec36e4fd383ec7ff8a64aa078"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.5"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: a2d56211ee4d35d9b344d9d4ce60f362e4f5d1aafb988302906bd732bc731276
+      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "2.4.5"
   webdriver:
     dependency: transitive
     description:
@@ -1081,5 +1081,5 @@ packages:
     source: hosted
     version: "0.0.3"
 sdks:
-  dart: ">=3.4.3 <4.0.0"
-  flutter: ">=3.22.2"
+  dart: ">=3.3.3 <4.0.0"
+  flutter: ">=3.19.6"

--- a/flutter_packages/prompting_client_ui/pubspec.yaml
+++ b/flutter_packages/prompting_client_ui/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_markdown: ^0.7.3
   flutter_riverpod: ^2.5.1
   freezed_annotation: ^2.4.1
+  handy_window: ^0.4.0
   intl: ^0.18.0
   json_annotation: ^4.9.0
   json_serializable: ^6.8.0

--- a/flutter_packages/prompting_client_ui/pubspec.yaml
+++ b/flutter_packages/prompting_client_ui/pubspec.yaml
@@ -5,8 +5,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.4.3 <4.0.0'
-  flutter: '>=3.22.2'
+  sdk: ">=3.3.3 <4.0.0"
+  flutter: ">=3.19.6"
 
 dependencies:
   args: ^2.5.0
@@ -16,7 +16,7 @@ dependencies:
   flutter_markdown: ^0.7.3
   flutter_riverpod: ^2.5.1
   freezed_annotation: ^2.4.1
-  intl: ^0.19.0
+  intl: ^0.18.0
   json_annotation: ^4.9.0
   json_serializable: ^6.8.0
   measure_size: ^4.0.0
@@ -24,7 +24,7 @@ dependencies:
   prompting_client: ^1.0.0
   riverpod_annotation: ^2.3.5
   ubuntu_lints: ^0.4.0
-  ubuntu_localizations: ^0.4.0
+  ubuntu_localizations: ^0.3.0
   ubuntu_logger: ^0.1.1
   ubuntu_service: ^0.3.2
   url_launcher: ^6.3.0
@@ -32,7 +32,7 @@ dependencies:
   yaru: ^4.1.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.9
   flutter_test:
     sdk: flutter
   freezed: ^2.5.2

--- a/melos.yaml
+++ b/melos.yaml
@@ -6,8 +6,8 @@ packages:
 command:
   bootstrap:
     environment:
-      sdk: ">=3.4.3 <4.0.0"
-      flutter: ">=3.22.2"
+      sdk: ">=3.3.3 <4.0.0"
+      flutter: ">=3.19.6"
 
     dev_dependencies:
       ubuntu_lints: ^0.4.0


### PR DESCRIPTION
Downgrades Flutter to 3.19.6 to avoid rendering issues still present in 3.24.1 and adds `handy_window` (rounded corners) for visual consistency

![image](https://github.com/user-attachments/assets/7d10b7fa-3c56-4304-8f77-25c8007d655f)

Note:
The `handy_window` plugin seems to have some conflicts with the `yaru_window` plugin, which prevents us from using `YaruWindow.onClose`. This means we'll need to handle the case in which the user closes the dialog in the rust client.