### PR TITLE
feat: adding new home pattern type to the GRPC API

### DIFF
--- a/flutter_packages/prompting_client/lib/src/generated/apparmor-prompting.pbenum.dart
+++ b/flutter_packages/prompting_client/lib/src/generated/apparmor-prompting.pbenum.dart
@@ -52,6 +52,7 @@ class HomePatternType extends $pb.ProtobufEnum {
   static const HomePatternType CONTAINING_DIRECTORY = HomePatternType._(3, _omitEnumNames ? '' : 'CONTAINING_DIRECTORY');
   static const HomePatternType HOME_DIRECTORY = HomePatternType._(4, _omitEnumNames ? '' : 'HOME_DIRECTORY');
   static const HomePatternType MATCHING_FILE_EXTENSION = HomePatternType._(5, _omitEnumNames ? '' : 'MATCHING_FILE_EXTENSION');
+  static const HomePatternType REQUESTED_DIRECTORY_CONTENTS = HomePatternType._(6, _omitEnumNames ? '' : 'REQUESTED_DIRECTORY_CONTENTS');
 
   static const $core.List<HomePatternType> values = <HomePatternType> [
     REQUESTED_DIRECTORY,
@@ -60,6 +61,7 @@ class HomePatternType extends $pb.ProtobufEnum {
     CONTAINING_DIRECTORY,
     HOME_DIRECTORY,
     MATCHING_FILE_EXTENSION,
+    REQUESTED_DIRECTORY_CONTENTS,
   ];
 
   static final $core.Map<$core.int, HomePatternType> _byValue = $pb.ProtobufEnum.initByValue(values);

--- a/flutter_packages/prompting_client/lib/src/generated/apparmor-prompting.pbjson.dart
+++ b/flutter_packages/prompting_client/lib/src/generated/apparmor-prompting.pbjson.dart
@@ -50,6 +50,7 @@ const HomePatternType$json = {
     {'1': 'CONTAINING_DIRECTORY', '2': 3},
     {'1': 'HOME_DIRECTORY', '2': 4},
     {'1': 'MATCHING_FILE_EXTENSION', '2': 5},
+    {'1': 'REQUESTED_DIRECTORY_CONTENTS', '2': 6},
   ],
 };
 
@@ -57,7 +58,8 @@ const HomePatternType$json = {
 final $typed_data.Uint8List homePatternTypeDescriptor = $convert.base64Decode(
     'Cg9Ib21lUGF0dGVyblR5cGUSFwoTUkVRVUVTVEVEX0RJUkVDVE9SWRAAEhIKDlJFUVVFU1RFRF'
     '9GSUxFEAESFwoTVE9QX0xFVkVMX0RJUkVDVE9SWRACEhgKFENPTlRBSU5JTkdfRElSRUNUT1JZ'
-    'EAMSEgoOSE9NRV9ESVJFQ1RPUlkQBBIbChdNQVRDSElOR19GSUxFX0VYVEVOU0lPThAF');
+    'EAMSEgoOSE9NRV9ESVJFQ1RPUlkQBBIbChdNQVRDSElOR19GSUxFX0VYVEVOU0lPThAFEiAKHF'
+    'JFUVVFU1RFRF9ESVJFQ1RPUllfQ09OVEVOVFMQBg==');
 
 @$core.Deprecated('Use promptReplyDescriptor instead')
 const PromptReply$json = {

--- a/flutter_packages/prompting_client/lib/src/prompting_client.dart
+++ b/flutter_packages/prompting_client/lib/src/prompting_client.dart
@@ -60,6 +60,8 @@ extension HomePatternTypeConversion on HomePatternType {
         pb.HomePatternType.HOME_DIRECTORY => HomePatternType.homeDirectory,
         pb.HomePatternType.MATCHING_FILE_EXTENSION =>
           HomePatternType.matchingFileExtension,
+        pb.HomePatternType.REQUESTED_DIRECTORY_CONTENTS =>
+          HomePatternType.requestedDirectoryContents,
         _ => throw ArgumentError('Unknown home pattern type: $homePatternType'),
       };
 }
@@ -122,8 +124,8 @@ extension PrompteDetailsConversion on PromptDetails {
                 .toSet(),
             initialPatternOption: response.homePrompt.initialPatternOption,
           ),
-        _ =>
-          throw ArgumentError('Unknown prompt type: ${response.whichPrompt()}'),
+        pb.GetCurrentPromptResponse_Prompt.notSet =>
+          throw ArgumentError('Prompt type not set'),
       };
 }
 

--- a/flutter_packages/prompting_client/lib/src/prompting_models.dart
+++ b/flutter_packages/prompting_client/lib/src/prompting_models.dart
@@ -13,6 +13,7 @@ enum HomePatternType {
   containingDirectory,
   homeDirectory,
   matchingFileExtension,
+  requestedDirectoryContents,
 }
 
 // Technically there is also a 'timespan' variant of this enum (on the

--- a/flutter_packages/prompting_client/test/prompting_client_test.dart
+++ b/flutter_packages/prompting_client/test/prompting_client_test.dart
@@ -209,6 +209,28 @@ void main() {
       });
     }
   });
+
+  group('home pattern type conversion is exhaustive', () {
+    for (final variant in pb.HomePatternType.values) {
+      test(variant.toString(), () {
+        // Just checking that we don't throw for any of the protobuf variants
+        HomePatternTypeConversion.fromProto(variant);
+      });
+    }
+  });
+
+  group('prompt reply response conversion is exhaustive', () {
+    for (final variant in pb.PromptReplyResponse_PromptReplyType.values) {
+      test(variant.toString(), () {
+        final response = pb.PromptReplyResponse(
+          promptReplyType: variant,
+          message: 'message',
+        );
+        // Just checking that we don't throw for any of the protobuf variants
+        PromptReplyResponseConversion.fromProto(response);
+      });
+    }
+  });
 }
 
 @GenerateMocks([pb.AppArmorPromptingClient])

--- a/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
@@ -59,6 +59,8 @@
             }
         }
     },
+    "homePatternTypeRequestedDirectoryContents": "Everything in the directory",
+    "@homePatternTypeRequestedDirectoryContents": {},
     "homePatternTypeContainingDirectory": "Everything in the directory",
     "@homePatternTypeContainingDirectory": {},
     "homePatternTypeHomeDirectory": "Everything in the Home directory",

--- a/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
@@ -47,11 +47,11 @@
     "@homePatternInfo": {},
     "homePatternTypeCustomPath": "Custom path pattern",
     "@homePatternTypeCustomPath": {},
-    "homePatternTypeRequestedDirectory": "The requested directory only",
+    "homePatternTypeRequestedDirectory": "The requested folder only",
     "@homePatternTypeRequestedDirectory": {},
     "homePatternTypeRequestedFile": "The requested file only",
     "@homePatternTypeRequestedFile": {},
-    "homePatternTypeTopLevelDirectory": "Everything in the {topLevelDir} directory",
+    "homePatternTypeTopLevelDirectory": "Everything in the {topLevelDir} folder",
     "@homePatternTypeTopLevelDirectory": {
         "placeholders": {
             "topLevelDir": {
@@ -59,11 +59,11 @@
             }
         }
     },
-    "homePatternTypeRequestedDirectoryContents": "Everything in the directory",
+    "homePatternTypeRequestedDirectoryContents": "Everything in the folder",
     "@homePatternTypeRequestedDirectoryContents": {},
-    "homePatternTypeContainingDirectory": "Everything in the directory",
+    "homePatternTypeContainingDirectory": "Everything in the folder",
     "@homePatternTypeContainingDirectory": {},
-    "homePatternTypeHomeDirectory": "Everything in the Home directory",
+    "homePatternTypeHomeDirectory": "Everything in the Home folder",
     "@homePatternTypeHomeDirectory": {},
     "homePatternTypeMatchingFileExtension": "Matching file extension",
     "@homePatternTypeMatchingFileExtension": {},

--- a/flutter_packages/prompting_client_ui/lib/l10n_x.dart
+++ b/flutter_packages/prompting_client_ui/lib/l10n_x.dart
@@ -29,6 +29,8 @@ extension HomePatternTypeL10n on HomePatternType {
         HomePatternType.homeDirectory => l10n.homePatternTypeHomeDirectory,
         HomePatternType.matchingFileExtension =>
           l10n.homePatternTypeMatchingFileExtension,
+        HomePatternType.requestedDirectoryContents =>
+          l10n.homePatternTypeRequestedDirectoryContents,
       };
 }
 

--- a/prompting-client/src/daemon/server.rs
+++ b/prompting-client/src/daemon/server.rs
@@ -248,7 +248,8 @@ fn map_pattern_option(
         PatternType => HomePatternType;
         [
             RequestedDirectory, RequestedFile, TopLevelDirectory,
-            HomeDirectory, MatchingFileExtension, ContainingDirectory
+            HomeDirectory, MatchingFileExtension, ContainingDirectory,
+            RequestedDirectoryContents
         ];
         pattern_type;
     );

--- a/prompting-client/src/protos/apparmor_prompting.rs
+++ b/prompting-client/src/protos/apparmor_prompting.rs
@@ -210,6 +210,7 @@ pub enum HomePatternType {
     ContainingDirectory = 3,
     HomeDirectory = 4,
     MatchingFileExtension = 5,
+    RequestedDirectoryContents = 6,
 }
 impl HomePatternType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -224,6 +225,7 @@ impl HomePatternType {
             HomePatternType::ContainingDirectory => "CONTAINING_DIRECTORY",
             HomePatternType::HomeDirectory => "HOME_DIRECTORY",
             HomePatternType::MatchingFileExtension => "MATCHING_FILE_EXTENSION",
+            HomePatternType::RequestedDirectoryContents => "REQUESTED_DIRECTORY_CONTENTS",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -235,6 +237,7 @@ impl HomePatternType {
             "CONTAINING_DIRECTORY" => Some(Self::ContainingDirectory),
             "HOME_DIRECTORY" => Some(Self::HomeDirectory),
             "MATCHING_FILE_EXTENSION" => Some(Self::MatchingFileExtension),
+            "REQUESTED_DIRECTORY_CONTENTS" => Some(Self::RequestedDirectoryContents),
             _ => None,
         }
     }

--- a/protos/apparmor-prompting.proto
+++ b/protos/apparmor-prompting.proto
@@ -75,6 +75,7 @@ enum HomePatternType {
     CONTAINING_DIRECTORY = 3;
     HOME_DIRECTORY = 4;
     MATCHING_FILE_EXTENSION = 5;
+    REQUESTED_DIRECTORY_CONTENTS = 6;
 }
 
 message MetaData {


### PR DESCRIPTION
The new variant isn't in use yet but I'm updating the Rust client next to include it in the generated options for subfolder paths. I missed updating the conversion method for `PromptReplyResponse` in a previous change and nearly did the same thing again here with `HomePatternType` so I've added some very simple regression tests that just iterate over the protobuf enum variants and check to see if anything throws when it gets run through the conversion method. If there's a more idiomatic way to handle this sort of check then please let me know and I'll move us over to that instead :smile: 

> For context, I don't _think_ we can simply rely on the match being marked as non-exhaustive as we are using generated "enum-_like_" classes with an explicit list of variants rather than true enums. If I'm wrong on this please let me know!

This also adds the new translation string required for the new option in the UI with the caveat that we are using `directory` everywhere rather than `folder` as this is what @local-optimum and Gustavo requested a while back. @juanruitina I see in your new Figma designs [here](https://www.figma.com/design/10xVr0m8efJh043Ff6SY4G/24.10-AppArmor-prompting?node-id=2084-4193&node-type=CANVAS&t=eFyJTz9wM1FfXMeS-0) that `folder` is still being used? I think we probably want to confirm with Oli which we are using when he's back and then either update the Figma or the translation strings accordingly. We use `directory` everywhere in the code base so the translation strings should be the only place that needs changing if that's the way we end up going.

Either way, I'll leave things as they currently stand for this PR rather than flip-flop between the two terms until we can confirm things :slightly_smiling_face: 