### PR TITLE
fix: only show the about this app section when metadata is available

### DIFF
--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_data_model.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_data_model.dart
@@ -28,6 +28,11 @@ class HomePromptData with _$HomePromptData {
 
   bool get isValid => permissions.isNotEmpty;
 
+  bool get hasMeta =>
+      (details.metaData.publisher?.isNotEmpty ?? false) &&
+      (details.metaData.storeUrl?.isNotEmpty ?? false) &&
+      details.metaData.updatedAt != null;
+
   String get topLevelDir {
     return details.requestedPath
         .replaceFirst(details.homeDir, '')

--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
@@ -19,11 +19,15 @@ class HomePromptPage extends ConsumerWidget {
     final showMoreOptions = ref.watch(
       homePromptDataModelProvider.select((m) => m.showMoreOptions),
     );
+    final hasMeta = ref.watch(
+      homePromptDataModelProvider.select((m) => m.hasMeta),
+    );
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const Header(),
-        const Divider(),
+        if (hasMeta) const Divider(),
         const PatternOptions(),
         const Permissions(),
         if (showMoreOptions) const LifespanToggle(),
@@ -38,8 +42,12 @@ class Header extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final details =
-        ref.watch(homePromptDataModelProvider.select((m) => m.details));
+    final details = ref.watch(
+      homePromptDataModelProvider.select((m) => m.details),
+    );
+    final hasMeta = ref.watch(
+      homePromptDataModelProvider.select((m) => m.hasMeta),
+    );
     final l10n = AppLocalizations.of(context);
 
     return Column(
@@ -55,7 +63,7 @@ class Header extends ConsumerWidget {
             details.requestedPath.bold(),
           ),
         ),
-        const MetaDataDropdown(),
+        if (hasMeta) const MetaDataDropdown(),
       ],
     );
   }

--- a/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' hide Action;
+import 'package:flutter/material.dart' hide Action, MetaData;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -15,6 +15,7 @@ void main() {
     snapName: 'firefox',
     publisher: 'Mozilla',
     updatedAt: DateTime(2024),
+    storeUrl: 'snap://firefox',
     requestedPath: '/home/ubuntu/Downloads/file.txt',
     homeDir: '/home/ubuntu',
     requestedPermissions: {Permission.read},
@@ -65,6 +66,48 @@ void main() {
     expect(
       find.text(tester.l10n.homePromptMetaDataPublishedBy('Mozilla')),
       findsOneWidget,
+    );
+  });
+
+  testWidgets('display prompt details without meta', (tester) async {
+    final container = createContainer();
+    final testDetailsWithoutMeta = testDetails.copyWith(
+      metaData: MetaData(
+        promptId: 'promptId',
+        snapName: 'firefox',
+        publisher: '',
+        storeUrl: '',
+      ),
+    );
+    registerMockPromptDetails(
+      promptDetails: testDetailsWithoutMeta,
+    );
+    await tester.pumpApp(
+      (_) => UncontrolledProviderScope(
+        container: container,
+        child: const PromptPage(),
+      ),
+    );
+
+    expect(
+      find.text(
+        tester.l10n.homePromptBody(
+          'firefox',
+          Permission.read.localize(tester.l10n).toLowerCase(),
+          '/home/ubuntu/Downloads/file.txt',
+        ),
+      ),
+      findsOneWidget,
+    );
+
+    expect(
+      find.text(tester.l10n.homePatternTypeTopLevelDirectory('Downloads')),
+      findsOneWidget,
+    );
+
+    expect(
+      find.text(tester.l10n.homePromptMetaDataPublishedBy('Mozilla')),
+      findsNothing,
     );
   });
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,4 +1,5 @@
 name: apparmor_prompting
+sdkPath: .fvm/flutter_sdk
 
 packages:
   - flutter_packages/**

--- a/melos.yaml
+++ b/melos.yaml
@@ -16,12 +16,12 @@ scripts:
   # build all packages
   build: >
     melos exec -c 1 --fail-fast --flutter --dir-exists=linux -- \
-      flutter build linux
+      fvm flutter build linux
 
   # collect coverage information for all packages
   coverage: >
     melos exec -c 1 --fail-fast --dir-exists=test -- \
-      flutter test --coverage && melos run coverage:cleanup
+      fvm flutter test --coverage && melos run coverage:cleanup
 
   # cleanup generated files from coverage
   coverage:cleanup: >
@@ -43,35 +43,35 @@ scripts:
       ! -path '*/l10n/*.dart' \
       ! -name '*.pb*.dart' \
       ! -path '*/.*/*' \
-      | xargs dart format --set-exit-if-changed
+      | xargs fvm dart format --set-exit-if-changed
 
   # run build_runner to generate code in all packages
   generate: >
     dart pub global run melos exec -c 1 --fail-fast --depends-on=build_runner -- \
-      dart run build_runner build --delete-conflicting-outputs
+      fvm dart run build_runner build --delete-conflicting-outputs
 
   # run build_runner in the background to watch for changes in all packages
   generate-watch: >
     melos exec -c 1 --depends-on=build_runner -- \
-      dart run build_runner watch -d &
+      fvm dart run build_runner watch -d &
 
   # run gen-l10n to generate localizations in all packages
   gen-l10n: >
     melos exec -c 1 --fail-fast --depends-on=flutter_localizations -- \
-     flutter gen-l10n
+     fvm flutter gen-l10n
 
   # run integration tests in all packages
   integration_test: >
     melos exec -c 1 --fail-fast --dir-exists=integration_test -- \
-      flutter test integration_test
+      fvm flutter test integration_test
 
   # runs "flutter pub <arg(s)>" in all packages
-  pub: melos exec -c 1 -- flutter pub "$@"
+  pub: melos exec -c 1 -- fvm flutter pub "$@"
 
   # run tests in all packages
   test: >
     melos exec -c 1 --fail-fast --dir-exists=test -- \
-      flutter test
+      fvm flutter test
 
   # generate protobuf files in prompting_client
   protoc:

--- a/prompting-client/src/snapd_client/mod.rs
+++ b/prompting-client/src/snapd_client/mod.rs
@@ -7,7 +7,7 @@ use hyper::Uri;
 use prompt::RawPrompt;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::HashMap, env, str::FromStr};
-use tracing::debug;
+use tracing::{debug, error};
 
 pub mod interfaces;
 mod prompt;
@@ -232,7 +232,10 @@ where
                 publisher: publisher.display_name,
             }),
 
-            Err(_) => None,
+            Err(e) => {
+                error!("unable to pull snap metadata for {name}: {e}");
+                None
+            }
         };
 
         // Serde structs


### PR DESCRIPTION
https://github.com/canonical/snapd/pull/14473 addresses the underlying cause of the "About this app" section ending up without any data to display (the rework of the prompting interface included trimming down the permissions it granted so we lost access to `/v2/snaps/$name`). From our side we also need to make sure that if the app metadata is not available, we no longer render the section in the prompt (see the screenshot below).

I've updated the tests in the UI to ensure that we don't render the "About this app" section when meta data is missing as a regression test for this.

![prompt-without-about](https://github.com/user-attachments/assets/18787d89-269b-4b16-88f0-2c2db1874317)

> @juanruitina "Custom path pattern" is still there because I've not started work on the UI fixes yet I'm afraid.

This PR also fixes the melos targets we have so that they correctly use `fvm` now that we are relying on it for managing the flutter version of the project.