### PR TITLE
fix: small UI fixes

### DIFF
--- a/flutter_packages/prompting_client_ui/integration_test/apparmor_prompt_test.dart
+++ b/flutter_packages/prompting_client_ui/integration_test/apparmor_prompt_test.dart
@@ -44,13 +44,12 @@ void main() {
     );
 
     // Show more options
-    final moreOptionsButton = find.text(tester.l10n.homePromptMoreOptionsLabel);
-    await tester.ensureVisible(moreOptionsButton);
-    await tester.tap(moreOptionsButton);
+    await tester
+        .ensureVisibleAndTap(find.text(tester.l10n.homePromptMoreOptionsLabel));
     await tester.pumpAndSettle();
 
     // Select 'custom prompt' to reveal text field
-    await tester.tap(
+    await tester.ensureVisibleAndTap(
       find.text(
         PatternOption(
           homePatternType: HomePatternType.customPath,
@@ -64,14 +63,25 @@ void main() {
     await tester.enterText(find.byType(TextField), '/home/ubuntu/**/');
 
     // Select lifespan
-    await tester.tap(find.text(Lifespan.forever.localize(tester.l10n)));
+    await tester
+        .ensureVisibleAndTap(find.text(Lifespan.forever.localize(tester.l10n)));
 
     // De-select 'read' permission, select 'execute' permission
-    await tester.tap(find.text(Permission.read.localize(tester.l10n)));
-    await tester.tap(find.text(Permission.execute.localize(tester.l10n)));
+    await tester
+        .ensureVisibleAndTap(find.text(Permission.read.localize(tester.l10n)));
+    await tester.ensureVisibleAndTap(
+        find.text(Permission.execute.localize(tester.l10n)));
 
     // Deny the request
-    await tester.tap(find.text(Action.deny.localize(tester.l10n)));
+    await tester
+        .ensureVisibleAndTap(find.text(Action.deny.localize(tester.l10n)));
     await tester.pumpAndSettle();
   });
+}
+
+extension on WidgetTester {
+  Future<void> ensureVisibleAndTap(FinderBase<Element> finder) async {
+    await ensureVisible(finder);
+    await tap(finder);
+  }
 }

--- a/flutter_packages/prompting_client_ui/integration_test/apparmor_prompt_test.dart
+++ b/flutter_packages/prompting_client_ui/integration_test/apparmor_prompt_test.dart
@@ -70,7 +70,8 @@ void main() {
     await tester
         .ensureVisibleAndTap(find.text(Permission.read.localize(tester.l10n)));
     await tester.ensureVisibleAndTap(
-        find.text(Permission.execute.localize(tester.l10n)));
+      find.text(Permission.execute.localize(tester.l10n)),
+    );
 
     // Deny the request
     await tester

--- a/flutter_packages/prompting_client_ui/integration_test/apparmor_prompt_test.dart
+++ b/flutter_packages/prompting_client_ui/integration_test/apparmor_prompt_test.dart
@@ -51,7 +51,12 @@ void main() {
 
     // Select 'custom prompt' to reveal text field
     await tester.tap(
-      find.text(HomePatternType.customPath.localize(tester.l10n, 'Documents')),
+      find.text(
+        PatternOption(
+          homePatternType: HomePatternType.customPath,
+          pathPattern: '',
+        ).localize(tester.l10n),
+      ),
     );
     await tester.pumpAndSettle();
 

--- a/flutter_packages/prompting_client_ui/integration_test/apparmor_prompt_test.dart
+++ b/flutter_packages/prompting_client_ui/integration_test/apparmor_prompt_test.dart
@@ -44,7 +44,9 @@ void main() {
     );
 
     // Show more options
-    await tester.tap(find.text(tester.l10n.homePromptMoreOptionsLabel));
+    final moreOptionsButton = find.text(tester.l10n.homePromptMoreOptionsLabel);
+    await tester.ensureVisible(moreOptionsButton);
+    await tester.tap(moreOptionsButton);
     await tester.pumpAndSettle();
 
     // Select 'custom prompt' to reveal text field

--- a/flutter_packages/prompting_client_ui/integration_test/apparmor_prompt_test.dart
+++ b/flutter_packages/prompting_client_ui/integration_test/apparmor_prompt_test.dart
@@ -43,6 +43,10 @@ void main() {
       findsOneWidget,
     );
 
+    // Show more options
+    await tester.tap(find.text(tester.l10n.homePromptMoreOptionsLabel));
+    await tester.pumpAndSettle();
+
     // Select 'custom prompt' to reveal text field
     await tester.tap(
       find.text(HomePatternType.customPath.localize(tester.l10n, 'Documents')),
@@ -51,10 +55,6 @@ void main() {
 
     // Enter custom path
     await tester.enterText(find.byType(TextField), '/home/ubuntu/**/');
-
-    // Show more options
-    await tester.tap(find.text(tester.l10n.homePromptMoreOptionsLabel));
-    await tester.pumpAndSettle();
 
     // Select lifespan
     await tester.tap(find.text(Lifespan.forever.localize(tester.l10n)));

--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_data_model.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_data_model.dart
@@ -32,12 +32,6 @@ class HomePromptData with _$HomePromptData {
       (details.metaData.publisher?.isNotEmpty ?? false) &&
       (details.metaData.storeUrl?.isNotEmpty ?? false) &&
       details.metaData.updatedAt != null;
-
-  String get topLevelDir {
-    return details.requestedPath
-        .replaceFirst(details.homeDir, '')
-        .split('/')[1];
-  }
 }
 
 @riverpod

--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
@@ -265,10 +265,7 @@ class PatternOptions extends ConsumerWidget {
                 pathPattern: '',
               ),
           ],
-          optionTitle: (option) => option.homePatternType.localize(
-            l10n,
-            model.topLevelDir,
-          ),
+          optionTitle: (option) => option.localize(l10n),
           optionSubtitle: (option) => switch (option) {
             PatternOption(homePatternType: HomePatternType.customPath) =>
               model.patternOption.homePatternType == HomePatternType.customPath

--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
@@ -259,10 +259,11 @@ class PatternOptions extends ConsumerWidget {
                 ),
           options: [
             ...patternOptions,
-            PatternOption(
-              homePatternType: HomePatternType.customPath,
-              pathPattern: '',
-            ),
+            if (model.showMoreOptions)
+              PatternOption(
+                homePatternType: HomePatternType.customPath,
+                pathPattern: '',
+              ),
           ],
           optionTitle: (option) => option.homePatternType.localize(
             l10n,

--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
@@ -282,7 +282,8 @@ class PatternOptions extends ConsumerWidget {
               errorText: model.errorMessage,
             ),
           ),
-          Text(l10n.homePatternInfo),
+          // TODO: re-enable when we have a link available for this to point to
+          // Text(l10n.homePatternInfo),
         ],
       ],
     );

--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
@@ -269,22 +269,49 @@ class PatternOptions extends ConsumerWidget {
             l10n,
             model.topLevelDir,
           ),
-          optionSubtitle: (option) => option.pathPattern,
+          optionSubtitle: (option) => switch (option) {
+            PatternOption(homePatternType: HomePatternType.customPath) =>
+              model.patternOption.homePatternType == HomePatternType.customPath
+                  ? const _CustomPathTextField()
+                  : const SizedBox.shrink(),
+            _ => Text(
+                option.pathPattern,
+                style: Theme.of(context).textTheme.labelSmall!.copyWith(
+                      color: Theme.of(context).hintColor,
+                    ),
+              ),
+          },
           groupValue: model.patternOption,
           onChanged: notifier.setPatternOption,
         ),
-        if (model.patternOption.homePatternType ==
-            HomePatternType.customPath) ...[
-          TextFormField(
-            initialValue: model.customPath,
-            onChanged: notifier.setCustomPath,
-            decoration: InputDecoration(
-              errorText: model.errorMessage,
-            ),
+      ],
+    );
+  }
+}
+
+class _CustomPathTextField extends ConsumerWidget {
+  const _CustomPathTextField();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final customPath =
+        ref.watch(homePromptDataModelProvider.select((m) => m.customPath));
+    final errorMessage =
+        ref.watch(homePromptDataModelProvider.select((m) => m.errorMessage));
+    final notifier = ref.read(homePromptDataModelProvider.notifier);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextFormField(
+          initialValue: customPath,
+          onChanged: notifier.setCustomPath,
+          decoration: InputDecoration(
+            errorText: errorMessage,
           ),
-          // TODO: re-enable when we have a link available for this to point to
-          // Text(l10n.homePatternInfo),
-        ],
+        ),
+        // Text(l10n.homePatternInfo),
+        // TODO: re-enable when we have a link available for this to point to
       ],
     );
   }

--- a/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
@@ -65,8 +65,14 @@
     "@homePatternTypeContainingDirectory": {},
     "homePatternTypeHomeDirectory": "Everything in the Home folder",
     "@homePatternTypeHomeDirectory": {},
-    "homePatternTypeMatchingFileExtension": "Matching file extension",
-    "@homePatternTypeMatchingFileExtension": {},
+    "homePatternTypeMatchingFileExtension": "All {fileExtension} files",
+    "@homePatternTypeMatchingFileExtension": {
+        "placeholders": {
+            "fileExtension": {
+                "type": "String"
+            }
+        }
+    },
     "homePromptBody": "Allow {snap} to have {permissions} access to {path}?",
     "@homePromptBody": {
         "placeholders": {

--- a/flutter_packages/prompting_client_ui/lib/l10n_x.dart
+++ b/flutter_packages/prompting_client_ui/lib/l10n_x.dart
@@ -16,19 +16,23 @@ extension LifespanL10n on Lifespan {
       };
 }
 
-extension HomePatternTypeL10n on HomePatternType {
-  String localize(AppLocalizations l10n, String topLevelDir) => switch (this) {
+extension PatternOptionL10n on PatternOption {
+  String localize(AppLocalizations l10n) => switch (homePatternType) {
         HomePatternType.customPath => l10n.homePatternTypeCustomPath,
         HomePatternType.requestedDirectory =>
           l10n.homePatternTypeRequestedDirectory,
         HomePatternType.requestedFile => l10n.homePatternTypeRequestedFile,
         HomePatternType.topLevelDirectory =>
-          l10n.homePatternTypeTopLevelDirectory(topLevelDir),
+          l10n.homePatternTypeTopLevelDirectory(
+            pathPattern.split('/**').first.split('/').last,
+          ),
         HomePatternType.containingDirectory =>
           l10n.homePatternTypeContainingDirectory,
         HomePatternType.homeDirectory => l10n.homePatternTypeHomeDirectory,
         HomePatternType.matchingFileExtension =>
-          l10n.homePatternTypeMatchingFileExtension,
+          l10n.homePatternTypeMatchingFileExtension(
+            pathPattern.split('.').last.toUpperCase(),
+          ),
         HomePatternType.requestedDirectoryContents =>
           l10n.homePatternTypeRequestedDirectoryContents,
       };

--- a/flutter_packages/prompting_client_ui/lib/test_prompt_details.json
+++ b/flutter_packages/prompting_client_ui/lib/test_prompt_details.json
@@ -27,6 +27,10 @@
             "pathPattern": "/home/user/**/*"
         },
         {
+            "homePatternType": "matchingFileExtension",
+            "pathPattern": "/home/user/**/*.jpeg"
+        },
+        {
             "homePatternType": "topLevelDirectory",
             "pathPattern": "/home/user/Downloads/**/*",
             "showInitially": true

--- a/flutter_packages/prompting_client_ui/lib/widgets/form_widgets.dart
+++ b/flutter_packages/prompting_client_ui/lib/widgets/form_widgets.dart
@@ -18,7 +18,7 @@ class RadioButtonList<T> extends StatelessWidget {
   final String title;
   final Iterable<T> options;
   final String Function(T option) optionTitle;
-  final String Function(T option)? optionSubtitle;
+  final Widget Function(T option)? optionSubtitle;
   final T? groupValue;
   final void Function(T?)? onChanged;
   final Axis direction;
@@ -40,14 +40,7 @@ class RadioButtonList<T> extends StatelessWidget {
                 groupValue: groupValue,
                 onChanged: onChanged,
                 title: Text(optionTitle(option)),
-                subtitle: optionSubtitle != null
-                    ? Text(
-                        optionSubtitle!(option),
-                        style: Theme.of(context).textTheme.labelSmall!.copyWith(
-                              color: Theme.of(context).hintColor,
-                            ),
-                      )
-                    : null,
+                subtitle: optionSubtitle?.call(option),
               ),
           ].withSpacing(direction == Axis.horizontal ? 16 : 0),
         ),

--- a/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -67,6 +67,21 @@ void main() {
       find.text(tester.l10n.homePromptMetaDataPublishedBy('Mozilla')),
       findsOneWidget,
     );
+
+    expect(
+      find.text(HomePatternType.customPath.localize(tester.l10n, 'Downloads')),
+      findsNothing,
+    );
+
+    await tester.tap(
+      find.text(tester.l10n.homePromptMoreOptionsLabel),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(HomePatternType.customPath.localize(tester.l10n, 'Downloads')),
+      findsOneWidget,
+    );
   });
 
   testWidgets('display prompt details without meta', (tester) async {
@@ -141,6 +156,11 @@ void main() {
         );
 
         await tester.tap(
+          find.text(tester.l10n.homePromptMoreOptionsLabel),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(
           find.text(
             HomePatternType.customPath.localize(tester.l10n, 'Downloads'),
           ),
@@ -148,7 +168,7 @@ void main() {
 
         final windowClosed = YaruTestWindow.waitForClosed();
 
-        await tester.tap(find.text(tester.l10n.promptActionOptionDenyOnce));
+        await tester.tap(find.text(tester.l10n.promptActionOptionDeny));
         await tester.pumpAndSettle();
 
         verify(
@@ -156,7 +176,7 @@ void main() {
             PromptReply.home(
               promptId: 'promptId',
               action: Action.deny,
-              lifespan: Lifespan.single,
+              lifespan: Lifespan.forever,
               pathPattern: '/home/ubuntu/Downloads/file.txt',
               permissions: {Permission.read},
             ),
@@ -185,11 +205,17 @@ void main() {
     );
 
     await tester.tap(
+      find.text(tester.l10n.homePromptMoreOptionsLabel),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
       find.text(HomePatternType.customPath.localize(tester.l10n, 'Downloads')),
     );
     await tester.pumpAndSettle();
+
     await tester.enterText(find.byType(TextFormField), 'invalid path');
-    await tester.tap(find.text(tester.l10n.promptActionOptionAllowAlways));
+    await tester.tap(find.text(tester.l10n.promptActionOptionAllow));
     await tester.pumpAndSettle();
 
     expect(find.text('error message'), findsOneWidget);

--- a/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -69,7 +69,7 @@ void main() {
     );
 
     expect(
-      find.text(HomePatternType.customPath.localize(tester.l10n, 'Downloads')),
+      find.text(tester.l10n.homePatternTypeCustomPath),
       findsNothing,
     );
 
@@ -79,7 +79,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text(HomePatternType.customPath.localize(tester.l10n, 'Downloads')),
+      find.text(tester.l10n.homePatternTypeCustomPath),
       findsOneWidget,
     );
   });
@@ -162,7 +162,7 @@ void main() {
 
         await tester.tap(
           find.text(
-            HomePatternType.customPath.localize(tester.l10n, 'Downloads'),
+            tester.l10n.homePatternTypeCustomPath,
           ),
         );
 
@@ -210,7 +210,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.tap(
-      find.text(HomePatternType.customPath.localize(tester.l10n, 'Downloads')),
+      find.text(tester.l10n.homePatternTypeCustomPath),
     );
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
This is tracked internally by https://warthogs.atlassian.net/browse/UDENG-4402

- [x] “Custom path pattern” is only ever visible when “more options” has been selected
- [x] The text input field of the “custom path pattern” option is aligned under the label text rather than the radio button
- [x] “Learn about path patterns” is removed until we have documentation to link to
- [ ] Text size for the radio button label text matches the other text in the UI
- [x] The text for the “matching file extensions” option is corrected to read "All {capitalised file extension} files" instead of "Matching file extension"