### PR TITLE
fix(prompting_ui): ensure the window is resized correctly

### DIFF
--- a/flutter_packages/prompting_client_ui/lib/prompt_page.dart
+++ b/flutter_packages/prompting_client_ui/lib/prompt_page.dart
@@ -5,8 +5,11 @@ import 'package:prompting_client/prompting_client.dart';
 import 'package:prompting_client_ui/home/home_prompt_page.dart';
 import 'package:prompting_client_ui/l10n.dart';
 import 'package:prompting_client_ui/prompt_model.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:yaru/yaru.dart';
+
+final _log = Logger('prompt_page');
 
 class PromptPage extends ConsumerWidget {
   const PromptPage({super.key});
@@ -25,8 +28,9 @@ class PromptPage extends ConsumerWidget {
       body: SingleChildScrollView(
         child: MeasureSizeBuilder(
           builder: (context, size) {
+            _log.debug('SizeChangedLayoutNotification received: $size');
             if (size.width >= 100 && size.height >= 100) {
-              windowManager.setSize(
+              _ensureWindowSize(
                 Size(
                   size.width,
                   size.height + kYaruTitleBarHeight,
@@ -46,5 +50,21 @@ class PromptPage extends ConsumerWidget {
         ),
       ),
     );
+  }
+}
+
+Future<void> _ensureWindowSize(Size size) async {
+  const delay = Duration(milliseconds: 100);
+  const maxRetries = 10;
+  var retries = 0;
+  do {
+    _log.debug('Setting window size to $size');
+    await windowManager.setSize(size);
+    await Future.delayed(delay);
+  } while (await windowManager.getSize() != size && retries++ < maxRetries);
+  if (retries >= maxRetries) {
+    _log.error('Failed to set window size to $size');
+  } else {
+    _log.debug('Window size set to $size');
   }
 }


### PR DESCRIPTION
This workaround fixes an issue presumably caused by a race condition during the initialization of the GTK window and the flutter view within that window.