### PR TITLE
test: add UI tests for all supported cases

### DIFF
--- a/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -35,53 +35,253 @@ void main() {
   );
   setUpAll(YaruTestWindow.ensureInitialized);
 
-  testWidgets('display prompt details', (tester) async {
-    final container = createContainer();
-    registerMockPromptDetails(
-      promptDetails: testDetails,
-    );
-    await tester.pumpApp(
-      (_) => UncontrolledProviderScope(
-        container: container,
-        child: const PromptPage(),
+  group('display prompt details', () {
+    for (final testCase in <({
+      String name,
+      String requestedPath,
+      Set<PatternOption> options,
+    })>[
+      (
+        name: 'file in subfolder',
+        requestedPath: '/home/user/Pictures/nested/foo.jpeg',
+        options: {
+          PatternOption(
+            homePatternType: HomePatternType.homeDirectory,
+            pathPattern: '/home/user/**',
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.topLevelDirectory,
+            pathPattern: '/home/user/Pictures/**',
+            showInitially: true,
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.containingDirectory,
+            pathPattern: '/home/user/Pictures/nested/**',
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.requestedFile,
+            pathPattern: '/home/user/Pictures/nested/foo.jpeg',
+            showInitially: true,
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.matchingFileExtension,
+            pathPattern: '/home/user/Pictures/nested/*.jpeg',
+          ),
+        },
       ),
-    );
-
-    expect(
-      find.text(
-        tester.l10n.homePromptBody(
-          'firefox',
-          Permission.read.localize(tester.l10n).toLowerCase(),
-          '/home/ubuntu/Downloads/file.txt',
-        ),
+      (
+        name: 'file in subfolder without extension',
+        requestedPath: '/home/user/Pictures/nested/foo',
+        options: {
+          PatternOption(
+            homePatternType: HomePatternType.homeDirectory,
+            pathPattern: '/home/user/**',
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.topLevelDirectory,
+            pathPattern: '/home/user/Pictures/**',
+            showInitially: true,
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.containingDirectory,
+            pathPattern: '/home/user/Pictures/nested/**',
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.requestedFile,
+            pathPattern: '/home/user/Pictures/nested/foo',
+            showInitially: true,
+          ),
+        },
       ),
-      findsOneWidget,
-    );
+      (
+        name: 'file in top level folder',
+        requestedPath: '/home/user/Downloads/foo.jpeg',
+        options: {
+          PatternOption(
+            homePatternType: HomePatternType.homeDirectory,
+            pathPattern: '/home/user/**',
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.topLevelDirectory,
+            pathPattern: '/home/user/Downloads/**',
+            showInitially: true,
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.requestedFile,
+            pathPattern: '/home/user/Downloads/foo.jpeg',
+            showInitially: true,
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.matchingFileExtension,
+            pathPattern: '/home/user/Downloads/*.jpeg',
+          ),
+        },
+      ),
+      (
+        name: 'file in top level folder without extension',
+        requestedPath: '/home/user/Downloads/foo',
+        options: {
+          PatternOption(
+            homePatternType: HomePatternType.homeDirectory,
+            pathPattern: '/home/user/**',
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.topLevelDirectory,
+            pathPattern: '/home/user/Downloads/**',
+            showInitially: true,
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.requestedFile,
+            pathPattern: '/home/user/Downloads/foo',
+            showInitially: true,
+          ),
+        },
+      ),
+      (
+        name: 'file in home folder',
+        requestedPath: '/home/user/foo.jpeg',
+        options: {
+          PatternOption(
+            homePatternType: HomePatternType.homeDirectory,
+            pathPattern: '/home/user/**',
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.requestedFile,
+            pathPattern: '/home/user/foo.jpeg',
+            showInitially: true,
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.matchingFileExtension,
+            pathPattern: '/home/user/*.jpeg',
+          ),
+        },
+      ),
+      (
+        name: 'file in home folder without extension',
+        requestedPath: '/home/user/foo',
+        options: {
+          PatternOption(
+            homePatternType: HomePatternType.homeDirectory,
+            pathPattern: '/home/user/**',
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.requestedFile,
+            pathPattern: '/home/user/foo',
+            showInitially: true,
+          ),
+        },
+      ),
+      (
+        name: 'sub folder',
+        requestedPath: '/home/user/Downloads/stuff/',
+        options: {
+          PatternOption(
+            homePatternType: HomePatternType.homeDirectory,
+            pathPattern: '/home/user/**',
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.topLevelDirectory,
+            pathPattern: '/home/user/Downloads/**',
+            showInitially: true,
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.requestedDirectoryContents,
+            pathPattern: '/home/user/Downloads/stuff/**',
+            showInitially: true,
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.requestedDirectory,
+            pathPattern: '/home/user/Downloads/stuff/',
+            showInitially: true,
+          ),
+        },
+      ),
+      (
+        name: 'top level folder',
+        requestedPath: '/home/user/Downloads/',
+        options: {
+          PatternOption(
+            homePatternType: HomePatternType.homeDirectory,
+            pathPattern: '/home/user/**',
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.topLevelDirectory,
+            pathPattern: '/home/user/Downloads/**',
+            showInitially: true,
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.requestedDirectory,
+            pathPattern: '/home/user/Downloads/',
+            showInitially: true,
+          ),
+        },
+      ),
+      (
+        name: 'top level folder',
+        requestedPath: '/home/user/',
+        options: {
+          PatternOption(
+            homePatternType: HomePatternType.homeDirectory,
+            pathPattern: '/home/user/**',
+          ),
+          PatternOption(
+            homePatternType: HomePatternType.requestedDirectory,
+            pathPattern: '/home/user/',
+          ),
+        },
+      ),
+    ]) {
+      testWidgets(testCase.name, (tester) async {
+        final container = createContainer();
+        registerMockPromptDetails(
+          promptDetails: testDetails.copyWith(
+            requestedPath: testCase.requestedPath,
+            patternOptions: testCase.options,
+          ),
+        );
+        await tester.pumpApp(
+          (_) => UncontrolledProviderScope(
+            container: container,
+            child: const PromptPage(),
+          ),
+        );
 
-    expect(
-      find.text(tester.l10n.homePatternTypeTopLevelDirectory('Downloads')),
-      findsOneWidget,
-    );
+        expect(
+          find.text(
+            tester.l10n.homePromptBody(
+              'firefox',
+              Permission.read.localize(tester.l10n).toLowerCase(),
+              testCase.requestedPath,
+            ),
+          ),
+          findsOneWidget,
+        );
 
-    expect(
-      find.text(tester.l10n.homePromptMetaDataPublishedBy('Mozilla')),
-      findsOneWidget,
-    );
+        expect(
+          find.text(tester.l10n.homePromptMetaDataPublishedBy('Mozilla')),
+          findsOneWidget,
+        );
 
-    expect(
-      find.text(tester.l10n.homePatternTypeCustomPath),
-      findsNothing,
-    );
+        for (final option in testCase.options.where((o) => o.showInitially)) {
+          expect(find.text(option.localize(tester.l10n)), findsOneWidget);
+          expect(find.text(option.pathPattern), findsOneWidget);
+        }
+        for (final option in testCase.options.where((o) => !o.showInitially)) {
+          expect(find.text(option.localize(tester.l10n)), findsNothing);
+          expect(find.text(option.pathPattern), findsNothing);
+        }
 
-    await tester.tap(
-      find.text(tester.l10n.homePromptMoreOptionsLabel),
-    );
-    await tester.pumpAndSettle();
+        await tester.tap(
+          find.text(tester.l10n.homePromptMoreOptionsLabel),
+        );
+        await tester.pumpAndSettle();
 
-    expect(
-      find.text(tester.l10n.homePatternTypeCustomPath),
-      findsOneWidget,
-    );
+        for (final option in testCase.options) {
+          expect(find.text(option.localize(tester.l10n)), findsOneWidget);
+          expect(find.text(option.pathPattern), findsOneWidget);
+        }
+      });
+    }
   });
 
   testWidgets('display prompt details without meta', (tester) async {

--- a/flutter_packages/prompting_client_ui/test/l10n_x_test.dart
+++ b/flutter_packages/prompting_client_ui/test/l10n_x_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart' hide Action, MetaData;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prompting_client/prompting_client.dart';
+import 'package:prompting_client_ui/l10n.dart';
+import 'package:prompting_client_ui/l10n_x.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  group('pattern options', () {
+    for (final testCase in <({
+      String name,
+      PatternOption option,
+      String Function(AppLocalizations l10n) expected,
+    })>[
+      (
+        name: 'custom path',
+        option: PatternOption(
+          homePatternType: HomePatternType.customPath,
+          pathPattern: '',
+        ),
+        expected: (l10n) => l10n.homePatternTypeCustomPath,
+      ),
+      (
+        name: 'requested directory',
+        option: PatternOption(
+          homePatternType: HomePatternType.requestedDirectory,
+          pathPattern: '/foo/bar/',
+        ),
+        expected: (l10n) => l10n.homePatternTypeRequestedDirectory
+      ),
+      (
+        name: 'requested file',
+        option: PatternOption(
+          homePatternType: HomePatternType.requestedFile,
+          pathPattern: '/foo/bar/baz.txt',
+        ),
+        expected: (l10n) => l10n.homePatternTypeRequestedFile
+      ),
+      (
+        name: 'top level directory',
+        option: PatternOption(
+          homePatternType: HomePatternType.topLevelDirectory,
+          pathPattern: '/foo/bar/**',
+        ),
+        expected: (l10n) => l10n.homePatternTypeTopLevelDirectory('bar')
+      ),
+      (
+        name: 'containing directory',
+        option: PatternOption(
+          homePatternType: HomePatternType.containingDirectory,
+          pathPattern: '/foo/bar/**',
+        ),
+        expected: (l10n) => l10n.homePatternTypeContainingDirectory
+      ),
+      (
+        name: 'home directory',
+        option: PatternOption(
+          homePatternType: HomePatternType.homeDirectory,
+          pathPattern: '/home/user/**',
+        ),
+        expected: (l10n) => l10n.homePatternTypeHomeDirectory
+      ),
+      (
+        name: 'matching file extension',
+        option: PatternOption(
+          homePatternType: HomePatternType.matchingFileExtension,
+          pathPattern: '/foo/bar/*.txt',
+        ),
+        expected: (l10n) => l10n.homePatternTypeMatchingFileExtension('TXT')
+      ),
+      (
+        name: 'requested directory contents',
+        option: PatternOption(
+          homePatternType: HomePatternType.requestedDirectoryContents,
+          pathPattern: '/foo/bar/**',
+        ),
+        expected: (l10n) => l10n.homePatternTypeRequestedDirectoryContents
+      ),
+    ]) {
+      testWidgets(testCase.name, (tester) async {
+        await tester.pumpApp((_) => const SizedBox());
+        expect(
+          testCase.option.localize(tester.l10n),
+          equals(testCase.expected(tester.l10n)),
+        );
+      });
+    }
+  });
+}


### PR DESCRIPTION
Generalizes the 'display prompt details' test to include all currently supported cases. So far it only asserts that:
* the options marked as `showInitially` are, in fact, shown initally
* all options are shown after pressing 'more options'
* the corresponding path patterns are displayed alongside the option titles

There's a separate test that verifies the l10n strings are created correctly (in particular for top level folders and matching file extensions).

UDENG-4478