### PR TITLE
fix: hide pattern options title when none shown initially

### DIFF
--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_data_model.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_data_model.dart
@@ -32,6 +32,10 @@ class HomePromptData with _$HomePromptData {
       (details.metaData.publisher?.isNotEmpty ?? false) &&
       (details.metaData.storeUrl?.isNotEmpty ?? false) &&
       details.metaData.updatedAt != null;
+
+  Iterable<PatternOption> get visiblePatternOptions => showMoreOptions
+      ? details.patternOptions
+      : details.patternOptions.where((option) => option.showInitially);
 }
 
 @riverpod

--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
@@ -19,16 +19,16 @@ class HomePromptPage extends ConsumerWidget {
     final showMoreOptions = ref.watch(
       homePromptDataModelProvider.select((m) => m.showMoreOptions),
     );
-    final hasMeta = ref.watch(
-      homePromptDataModelProvider.select((m) => m.hasMeta),
+    final hasVisibleOptions = ref.watch(
+      homePromptDataModelProvider
+          .select((m) => m.visiblePatternOptions.isNotEmpty),
     );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const Header(),
-        if (hasMeta) const Divider(),
-        const PatternOptions(),
+        if (hasVisibleOptions) ...[const Divider(), const PatternOptions()],
         const Permissions(),
         if (showMoreOptions) const LifespanToggle(),
         const ActionButtonRow(),
@@ -241,47 +241,38 @@ class PatternOptions extends ConsumerWidget {
     final notifier = ref.read(homePromptDataModelProvider.notifier);
     final l10n = AppLocalizations.of(context);
 
-    final patternOptions = model.showMoreOptions
-        ? model.details.patternOptions
-        : model.details.patternOptions.where((option) => option.showInitially);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        RadioButtonList<PatternOption>(
-          title: model.showMoreOptions
-              ? l10n
-                  .promptAccessMoreOptionsTitle(model.details.metaData.snapName)
-              : l10n.promptAccessTitle(
-                  model.details.metaData.snapName,
-                  model.details.requestedPermissions
-                      .map((p) => p.localize(l10n).toLowerCase())
-                      .join(', '),
-                ),
-          options: [
-            ...patternOptions,
-            if (model.showMoreOptions)
-              PatternOption(
-                homePatternType: HomePatternType.customPath,
-                pathPattern: '',
-              ),
-          ],
-          optionTitle: (option) => option.localize(l10n),
-          optionSubtitle: (option) => switch (option) {
-            PatternOption(homePatternType: HomePatternType.customPath) =>
-              model.patternOption.homePatternType == HomePatternType.customPath
-                  ? const _CustomPathTextField()
-                  : const SizedBox.shrink(),
-            _ => Text(
-                option.pathPattern,
-                style: Theme.of(context).textTheme.labelSmall!.copyWith(
-                      color: Theme.of(context).hintColor,
-                    ),
-              ),
-          },
-          groupValue: model.patternOption,
-          onChanged: notifier.setPatternOption,
-        ),
+    return RadioButtonList<PatternOption>(
+      title: model.showMoreOptions
+          ? l10n.promptAccessMoreOptionsTitle(model.details.metaData.snapName)
+          : l10n.promptAccessTitle(
+              model.details.metaData.snapName,
+              model.details.requestedPermissions
+                  .map((p) => p.localize(l10n).toLowerCase())
+                  .join(', '),
+            ),
+      options: [
+        ...model.visiblePatternOptions,
+        if (model.showMoreOptions)
+          PatternOption(
+            homePatternType: HomePatternType.customPath,
+            pathPattern: '',
+          ),
       ],
+      optionTitle: (option) => option.localize(l10n),
+      optionSubtitle: (option) => switch (option) {
+        PatternOption(homePatternType: HomePatternType.customPath) =>
+          model.patternOption.homePatternType == HomePatternType.customPath
+              ? const _CustomPathTextField()
+              : const SizedBox.shrink(),
+        _ => Text(
+            option.pathPattern,
+            style: Theme.of(context).textTheme.labelSmall!.copyWith(
+                  color: Theme.of(context).hintColor,
+                ),
+          ),
+      },
+      groupValue: model.patternOption,
+      onChanged: notifier.setPatternOption,
     );
   }
 }


### PR DESCRIPTION
If there are no initially shown pattern options, also hide the 'Give <snap> <pemission> access to:' title.
I've moved things around a bit and it should now match the figma designs.

What's still a bit subtle: when no radio buttons are visible to the user, the implicitly selected option corresponds to the `initialPatternOption` submitted by the rust client who is then responsible for making sure this is either `requestedFile` or `requestedDirectory`.