### PR TITLE
chore: publish the integration tests binary for snapd

### DIFF
--- a/.github/workflows/publish-integration-tests.yaml
+++ b/.github/workflows/publish-integration-tests.yaml
@@ -30,3 +30,15 @@ jobs:
           name: integration-tests
           path: prompting-client/integration-tests
           compression-level: 0 # no compression
+
+      - name: Build testing snap
+        id: snapcraft-testing
+        uses: snapcore/action-build@v1
+        with:
+          path: testing-snap
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: aa-prompting-test
+          path: ${{ steps.snapcraft-testing.outputs.snap }}
+          compression-level: 0 # no compression

--- a/.github/workflows/publish-integration-tests.yaml
+++ b/.github/workflows/publish-integration-tests.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: compile
         working-directory: ./prompting-client
         run: |
+          sudo apt-get install protobuf-compiler
           cargo test --no-run
           FNAME=$(
             ls -ht target/debug/deps/integration* |

--- a/.github/workflows/publish-integration-tests.yaml
+++ b/.github/workflows/publish-integration-tests.yaml
@@ -11,8 +11,9 @@ jobs:
   publish:
     runs-on: ubuntu-22.04
     steps:
-      - name: Publish integration tests
       - uses: actions/checkout@v4
+
+      - name: compile
         working-directory: ./prompting-client
         run: |
           cargo test --no-run
@@ -22,6 +23,7 @@ jobs:
               head -n1
           )
           cp $FNAME integration-tests
+
       - uses: actions/upload-artifact@v4
         with:
           name: integration-tests

--- a/.github/workflows/publish-integration-tests.yaml
+++ b/.github/workflows/publish-integration-tests.yaml
@@ -1,0 +1,29 @@
+name: Publish integration tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Publish integration tests
+      - uses: actions/checkout@v4
+        working-directory: ./prompting-client
+        run: |
+          cargo test --no-run
+          FNAME=$(
+            ls -ht target/debug/deps/integration* |
+              grep -Ev '\.d' |
+              head -n1
+          )
+          cp $FNAME integration-tests
+      - uses: actions/upload-artifact@v4
+        with:
+          name: integration-tests
+          path: prompting-client/integration-tests
+          compression-level: 0 # no compression


### PR DESCRIPTION
@olivercalder I think this should do the trick? If it works as intended then the APIs described here should work for locating and downloading the artifact: https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28