### PR TITLE
feat(prompting_ui): add 'allow once' button, demote 'more options'

### DIFF
--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
@@ -150,7 +150,7 @@ class ActionButtons extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(children: buttons.withSpacing(16)),
+        Wrap(runSpacing: 16, spacing: 16, children: buttons),
         if (!showMoreOptions) const MoreOptionsButton(),
       ].withSpacing(16),
     );

--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
@@ -31,7 +31,7 @@ class HomePromptPage extends ConsumerWidget {
         if (hasVisibleOptions) ...[const Divider(), const PatternOptions()],
         const Permissions(),
         if (showMoreOptions) const LifespanToggle(),
-        const ActionButtonRow(),
+        const ActionButtons(),
       ].withSpacing(20),
     );
   }
@@ -129,8 +129,8 @@ class MetaDataDropdown extends ConsumerWidget {
   }
 }
 
-class ActionButtonRow extends ConsumerWidget {
-  const ActionButtonRow({super.key});
+class ActionButtons extends ConsumerWidget {
+  const ActionButtons({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -144,10 +144,16 @@ class ActionButtonRow extends ConsumerWidget {
           ]
         : const [
             ActionButton(action: Action.allow, lifespan: Lifespan.forever),
+            ActionButton(action: Action.allow, lifespan: Lifespan.single),
             ActionButton(action: Action.deny, lifespan: Lifespan.single),
-            MoreOptionsButton(),
           ];
-    return Row(children: buttons.withSpacing(16));
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(children: buttons.withSpacing(16)),
+        if (!showMoreOptions) const MoreOptionsButton(),
+      ].withSpacing(16),
+    );
   }
 }
 
@@ -186,6 +192,7 @@ class ActionButton extends ConsumerWidget {
           (final action, null) => action.localize(l10n),
           (Action.allow, Lifespan.forever) =>
             l10n.promptActionOptionAllowAlways,
+          (Action.allow, Lifespan.single) => l10n.promptActionOptionAllowOnce,
           (Action.deny, Lifespan.single) => l10n.promptActionOptionDenyOnce,
           (final action, final Lifespan lifespan) =>
             '${action.localize(l10n)} (${lifespan.name})',
@@ -200,10 +207,19 @@ class MoreOptionsButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return OutlinedButton(
-      onPressed:
-          ref.read(homePromptDataModelProvider.notifier).toggleMoreOptions,
-      child: Text(AppLocalizations.of(context).homePromptMoreOptionsLabel),
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: ref.read(homePromptDataModelProvider.notifier).toggleMoreOptions,
+        child: Text(
+          AppLocalizations.of(context).homePromptMoreOptionsLabel,
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.primary,
+            decoration: TextDecoration.underline,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
@@ -25,6 +25,8 @@
     "@promptActionOptionAllow": {},
     "promptActionOptionAllowAlways": "Allow always",
     "@promptActionOptionAllowAlways": {},
+    "promptActionOptionAllowOnce": "Allow once",
+    "@promptActionOptionAllowOnce": {},
     "promptActionOptionDeny": "Deny",
     "@promptActionOptionDeny": {},
     "promptActionOptionDenyOnce": "Deny once",


### PR DESCRIPTION
Adds an 'allow once' button and de-emphasizes the 'more options' button in accordance with the updated Figma designs.

![image](https://github.com/user-attachments/assets/d412f9c4-22d0-4f17-a703-9279ebdef662)

I've also made sure the buttons overflow into the next line in case there isn't enough horizontal space (which might happen for some languages)

![image](https://github.com/user-attachments/assets/d3fbd77a-214b-4afd-9110-ec823986b7d6)


UDENG-4494