### PR TITLE
fix(daemon): exiting if we get permission denied on notices long poll

### DIFF
--- a/prompting-client/src/bin/echo.rs
+++ b/prompting-client/src/bin/echo.rs
@@ -1,7 +1,5 @@
 use clap::Parser;
-use prompting_client::{
-    cli_actions::run_echo_loop, snapd_client::SnapdSocketClient, Error, Result,
-};
+use prompting_client::{cli_actions::run_echo_loop, snapd_client::SnapdSocketClient, Result};
 
 /// A simple echo prompting client for apparmor prompting that echos all prompts seen on the system
 /// for the user running it.
@@ -17,11 +15,7 @@ struct Args {
 async fn main() -> Result<()> {
     let Args { record } = Args::parse();
     let mut c = SnapdSocketClient::default();
-
-    if !c.is_prompting_enabled().await? {
-        eprintln!("the prompting feature is not enabled: exiting");
-        return Err(Error::NotEnabled);
-    }
+    c.exit_if_prompting_not_enabled().await?;
 
     run_echo_loop(&mut c, record).await
 }

--- a/prompting-client/src/bin/scripted.rs
+++ b/prompting-client/src/bin/scripted.rs
@@ -42,10 +42,7 @@ async fn main() -> Result<()> {
     }
 
     let mut c = SnapdSocketClient::default();
-    if !c.is_prompting_enabled().await? {
-        println!("error: prompting is not enabled");
-        return Ok(());
-    }
+    c.exit_if_prompting_not_enabled().await?;
 
     run_scripted_client_loop(&mut c, script, grace_period).await
 }

--- a/prompting-client/src/lib.rs
+++ b/prompting-client/src/lib.rs
@@ -9,6 +9,7 @@
     clippy::undocumented_unsafe_blocks
 )]
 
+use hyper::StatusCode;
 use prompt_sequence::MatchError;
 
 pub mod cli_actions;
@@ -28,11 +29,6 @@ pub const DEFAULT_LOG_LEVEL: &str = "info";
 pub fn log_filter(filter: &str) -> String {
     format!("{filter},hyper=error,h2=error")
 }
-
-// FIXME: having to hard code these is a problem.
-// We need snapd to provide structured errors we can work with programatically.
-pub(crate) const PROMPT_NOT_FOUND: &str = "cannot find prompt with the given ID for the given user";
-pub(crate) const NO_PROMPTS_FOR_USER: &str = "no prompts found for the given user";
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -76,7 +72,7 @@ pub enum Error {
     NotSupported { reason: String },
 
     #[error("error message returned from snapd: {message}")]
-    SnapdError { message: String },
+    SnapdError { status: StatusCode, message: String },
 
     #[error("{interface} is not currently supported for apparmor prompting")]
     UnsupportedInterface { interface: String },

--- a/prompting-client/tests/integration.rs
+++ b/prompting-client/tests/integration.rs
@@ -256,7 +256,7 @@ async fn requesting_an_unknown_prompt_id_is_an_error() -> Result<()> {
         .await;
 
     match res {
-        Err(Error::SnapdError { message }) => {
+        Err(Error::SnapdError { message, .. }) => {
             assert_eq!(message, PROMPT_NOT_FOUND, "unexpected message")
         }
         Err(e) => panic!("expected a snapd error, got: {e}"),
@@ -281,7 +281,7 @@ async fn incorrect_custom_paths_error(reply_path: &str, expected_prefix: &str) -
         .into();
 
     match c.reply_to_prompt(&id, reply).await {
-        Err(Error::SnapdError { message }) => assert!(
+        Err(Error::SnapdError { message, .. }) => assert!(
             message.starts_with(expected_prefix),
             "message format not as expected: {message:?}"
         ),
@@ -312,7 +312,7 @@ async fn invalid_timeperiod_duration_errors(timespan: &str, expected_prefix: &st
         .into();
 
     match c.reply_to_prompt(&id, reply).await {
-        Err(Error::SnapdError { message }) => assert!(
+        Err(Error::SnapdError { message, .. }) => assert!(
             message.starts_with(&format!("invalid duration: {expected_prefix}")),
             "message format not as expected: {message}"
         ),
@@ -364,7 +364,7 @@ async fn replying_multiple_times_errors(
         .await;
 
     match res {
-        Err(Error::SnapdError { message }) => {
+        Err(Error::SnapdError { message, .. }) => {
             assert_eq!(message, PROMPT_NOT_FOUND, "unexpected message")
         }
         Err(e) => panic!("expected a snapd error, got: {e}"),


### PR DESCRIPTION
- update our handling of snapd errors to make use of consistent error codes
- factor out repeated logic around checking if prompting is enabled
- exit so systemd restarts us if we hit permission denied in the poll loop
- retry with limited attempts and a sleep if we hit other errors in the poll loop