### PR TITLE
feat(scripted-client): supporting passing templating variables and a top level filter

### DIFF
--- a/prompting-client/resources/prompt-sequence-tests/e2e_erroring_write_test.json
+++ b/prompting-client/resources/prompt-sequence-tests/e2e_erroring_write_test.json
@@ -6,7 +6,7 @@
        "snap": "aa-prompting-test",
        "interface": "home",
        "constraints": {
-         "path": "/home/[a-zA-Z0-9]+/test/.+/test-1.txt",
+         "path": "$BASE_PATH/test-1.txt",
          "requested-permissions": [ "write" ],
          "available-permissions": [ "read", "write", "execute" ]
        }

--- a/prompting-client/resources/prompt-sequence-tests/e2e_unexpected_additional_prompt_test.json
+++ b/prompting-client/resources/prompt-sequence-tests/e2e_unexpected_additional_prompt_test.json
@@ -1,12 +1,19 @@
 {
   "version": 1,
+  "prompt-filter": {
+    "snap": "aa-prompting-test",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/*"
+    }
+  },
   "prompts": [
     {
       "prompt-filter": {
         "snap": "aa-prompting-test",
         "interface": "home",
         "constraints": {
-          "path": "/home/[a-zA-Z0-9]+/test/.+/test-1.txt",
+          "path": ".*/test-1.txt",
           "requested-permissions": [ "write" ],
           "available-permissions": [ "read", "write", "execute" ]
         }
@@ -24,7 +31,7 @@
         "snap": "aa-prompting-test",
         "interface": "home",
         "constraints": {
-          "path": "/home/[a-zA-Z0-9]+/test/.+/test-2.txt",
+          "path": ".*/test-2.txt",
           "requested-permissions": [ "write" ],
           "available-permissions": [ "read", "write", "execute" ]
         }

--- a/prompting-client/resources/prompt-sequence-tests/e2e_write_test.json
+++ b/prompting-client/resources/prompt-sequence-tests/e2e_write_test.json
@@ -1,12 +1,17 @@
 {
   "version": 1,
+  "prompt-filter": {
+    "snap": "aa-prompting-test",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/*"
+    }
+  },
   "prompts": [
     {
       "prompt-filter": {
-        "snap": "aa-prompting-test",
-        "interface": "home",
         "constraints": {
-          "path": "/home/[a-zA-Z0-9]+/test/.+/test-1.txt",
+          "path": ".*/test-1.txt",
           "requested-permissions": [ "write" ],
           "available-permissions": [ "read", "write", "execute" ]
         }
@@ -21,10 +26,8 @@
     },
     {
       "prompt-filter": {
-        "snap": "aa-prompting-test",
-        "interface": "home",
         "constraints": {
-          "path": "/home/[a-zA-Z0-9]+/test/.+/test-2.txt",
+          "path": ".*/test-2.txt",
           "requested-permissions": [ "write" ],
           "available-permissions": [ "read", "write", "execute" ]
         }
@@ -33,16 +36,15 @@
         "action": "allow",
         "lifespan": "forever",
         "constraints": {
+          "path": "${PROMPT_PATH}/../**",
           "permissions": [ "read", "write" ]
         }
       }
     },
     {
       "prompt-filter": {
-        "snap": "aa-prompting-test",
-        "interface": "home",
         "constraints": {
-          "path": "/home/[a-zA-Z0-9]+/test/.+/test-3.txt",
+          "path": ".*/test-3.txt",
           "requested-permissions": [ "write" ],
           "available-permissions": [ "read", "write", "execute" ]
         }

--- a/prompting-client/resources/prompt-sequence-tests/e2e_wrong_path_test.json
+++ b/prompting-client/resources/prompt-sequence-tests/e2e_wrong_path_test.json
@@ -6,7 +6,7 @@
         "snap": "aa-prompting-test",
         "interface": "home",
         "constraints": {
-          "path": "/home/[a-zA-Z0-9]+/test/.+/test-1.txt",
+          "path": "$BASE_PATH/test-1.txt",
           "requested-permissions": [ "write" ],
           "available-permissions": [ "read", "write", "execute" ]
         }
@@ -24,7 +24,7 @@
         "snap": "aa-prompting-test",
         "interface": "home",
         "constraints": {
-          "path": "/home/[a-zA-Z0-9]+/test/.+/incorrect.txt",
+          "path": "$BASE_PATH/incorrect.txt",
           "requested-permissions": [ "read" ],
           "available-permissions": [ "read", "write", "execute" ]
         }

--- a/prompting-client/resources/prompt-sequence-tests/sequence_with_top_level_filter_and_vars.json
+++ b/prompting-client/resources/prompt-sequence-tests/sequence_with_top_level_filter_and_vars.json
@@ -1,0 +1,31 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "aa-prompting-test",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "snap": "testSnap",
+        "interface": "home",
+        "constraints": {
+          "path": "$BASE_PATH/bar",
+          "requested-permissions": [ "read" ],
+          "available-permissions": [ "read", "write", "execute" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/bar",
+          "permissions": [ "read", "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/prompting-client/resources/scripted-tests/happy-path-read/prompt-sequence.json
+++ b/prompting-client/resources/scripted-tests/happy-path-read/prompt-sequence.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "aa-prompting-test",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test.txt",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test.txt",
+          "permissions": [ "read" ]
+        }
+      }
+    }
+  ]
+}

--- a/prompting-client/resources/scripted-tests/happy-path-read/test.sh
+++ b/prompting-client/resources/scripted-tests/happy-path-read/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+# A simple allow once test of a read prompt.
+# Running this test script requires that the accompanying prompt-sequence.json
+# file be present in the output directory.
+
+PREFIX="$1"
+TEST_DIR="/home/ubuntu/test/$PREFIX"
+
+prompting-client.scripted \
+  --script="$TEST_DIR/prompt-sequence.json" \
+  --var "BASE_PATH:$TEST_DIR" | tee "$TEST_DIR/outfile" &
+
+# Ensure that the test client is already listening
+sleep 0.2
+TEST_OUTPUT="$(aa-prompting-test.read "$PREFIX")"
+
+# Ensure that the test client has time to write its output
+# For tests with a grace period this will need to be taken into account as well
+sleep 0.2
+CLIENT_OUTPUT="$(cat "$TEST_DIR/outfile")"
+
+if [ "$CLIENT_OUTPUT" != "success" ]; then
+  echo "test failed"
+  echo "output='$CLIENT_OUTPUT'"
+  exit 1
+fi
+
+if [ "$TEST_OUTPUT" != "testing testing 1 2 3" ]; then
+  echo "test script failed"
+  exit 1
+fi

--- a/prompting-client/src/cli_actions/mod.rs
+++ b/prompting-client/src/cli_actions/mod.rs
@@ -4,4 +4,4 @@ mod scripted;
 
 pub use echo_loop::run_echo_loop;
 pub use log_level::set_logging_filter;
-pub use scripted::run_scripted_client_loop;
+pub use scripted::ScriptedClient;

--- a/prompting-client/src/cli_actions/scripted.rs
+++ b/prompting-client/src/cli_actions/scripted.rs
@@ -15,53 +15,6 @@ use std::time::Duration;
 use tokio::{select, sync::mpsc::unbounded_channel};
 use tracing::{debug, error, info, warn};
 
-/// Run a scripted client that actions prompts based on a predefined sequence of prompts that we
-/// expect to see.
-pub async fn run_scripted_client_loop(
-    snapd_client: &mut SnapdSocketClient,
-    path: String,
-    vars: &[(&str, &str)],
-    grace_period: Option<u64>,
-) -> Result<()> {
-    eprintln!("creating client");
-    let mut scripted_client =
-        ScriptedClient::try_new_allowing_script_read(path, vars, snapd_client.clone())?;
-    let (tx_prompts, mut rx_prompts) = unbounded_channel();
-
-    info!("starting poll loop");
-    let mut poll_loop = PollLoop::new(snapd_client.clone(), tx_prompts);
-    poll_loop.skip_outstanding_prompts();
-    tokio::spawn(async move { poll_loop.run().await });
-
-    info!(
-        script=%scripted_client.path,
-        n_prompts=%scripted_client.seq.len(),
-        "running provided script"
-    );
-
-    while scripted_client.is_running() {
-        match rx_prompts.recv().await {
-            Some(PromptUpdate::Add(ep)) if scripted_client.should_handle(&ep) => {
-                scripted_client.reply(ep, snapd_client).await?
-            }
-            Some(PromptUpdate::Add(ep)) => eprintln!("dropping prompt: {ep:?}"),
-            Some(PromptUpdate::Drop(PromptId(id))) => warn!(%id, "drop for prompt id"),
-            None => break,
-        }
-    }
-
-    let grace_period = match grace_period {
-        Some(n) => n,
-        None => return Ok(()),
-    };
-
-    info!(seconds=%grace_period, "sequence complete, entering grace period");
-    select! {
-        _ = tokio::time::sleep(Duration::from_secs(grace_period)) => Ok(()),
-        res = grace_period_deny_and_error(snapd_client) => res,
-    }
-}
-
 /// Poll for outstanding prompts and auto-deny them before returning an error. This function will
 /// loop until at least one un-actioned prompt is encountered.
 async fn grace_period_deny_and_error(snapd_client: &mut SnapdSocketClient) -> Result<()> {
@@ -94,13 +47,14 @@ async fn grace_period_deny_and_error(snapd_client: &mut SnapdSocketClient) -> Re
 }
 
 #[derive(Debug)]
-struct ScriptedClient {
+pub struct ScriptedClient {
     seq: PromptSequence,
+    raw_seq: String,
     path: String,
 }
 
 impl ScriptedClient {
-    fn try_new_allowing_script_read(
+    pub fn try_new(
         path: String,
         vars: &[(&str, &str)],
         mut snapd_client: SnapdSocketClient,
@@ -140,9 +94,52 @@ impl ScriptedClient {
             }
         });
 
-        let seq = PromptSequence::try_new_from_file(&path, vars)?;
+        let (seq, raw_seq) = PromptSequence::try_new_from_file(&path, vars)?;
 
-        Ok(Self { seq, path })
+        Ok(Self { seq, raw_seq, path })
+    }
+
+    pub fn raw_seq(&self) -> &str {
+        &self.raw_seq
+    }
+
+    /// Run a scripted client that actions prompts based on a predefined sequence of prompts that we
+    /// expect to see.
+    pub async fn run(
+        &mut self,
+        snapd_client: &mut SnapdSocketClient,
+        grace_period: Option<u64>,
+    ) -> Result<()> {
+        let (tx_prompts, mut rx_prompts) = unbounded_channel();
+
+        info!("starting poll loop");
+        let mut poll_loop = PollLoop::new(snapd_client.clone(), tx_prompts);
+        poll_loop.skip_outstanding_prompts();
+        tokio::spawn(async move { poll_loop.run().await });
+
+        info!(script=%self.path, n_prompts=%self.seq.len(), "running provided script");
+
+        while self.is_running() {
+            match rx_prompts.recv().await {
+                Some(PromptUpdate::Add(ep)) if self.should_handle(&ep) => {
+                    self.reply(ep, snapd_client).await?
+                }
+                Some(PromptUpdate::Add(ep)) => eprintln!("dropping prompt: {ep:?}"),
+                Some(PromptUpdate::Drop(PromptId(id))) => warn!(%id, "drop for prompt id"),
+                None => break,
+            }
+        }
+
+        let grace_period = match grace_period {
+            Some(n) => n,
+            None => return Ok(()),
+        };
+
+        info!(seconds=%grace_period, "sequence complete, entering grace period");
+        select! {
+            _ = tokio::time::sleep(Duration::from_secs(grace_period)) => Ok(()),
+            res = grace_period_deny_and_error(snapd_client) => res,
+        }
     }
 
     fn should_handle(&self, ep: &EnrichedPrompt) -> bool {

--- a/prompting-client/src/lib.rs
+++ b/prompting-client/src/lib.rs
@@ -59,6 +59,9 @@ pub enum Error {
     #[error("{version} is not supported recording version.")]
     InvalidRecordingVersion { version: u8 },
 
+    #[error("invalid script variable. Expected 'key:value' but saw {raw:?}")]
+    InvalidScriptVariable { raw: String },
+
     #[error("{uri} is not valid: {reason}")]
     InvalidUri { reason: &'static str, uri: String },
 

--- a/prompting-client/src/prompt_sequence.rs
+++ b/prompting-client/src/prompt_sequence.rs
@@ -19,18 +19,18 @@ pub struct PromptSequence {
 }
 
 impl PromptSequence {
-    pub fn try_new_from_file(path: &str, vars: &[(&str, &str)]) -> crate::Result<Self> {
+    pub fn try_new_from_file(path: &str, vars: &[(&str, &str)]) -> crate::Result<(Self, String)> {
         Self::try_new_from_string(fs::read_to_string(path)?, vars)
     }
 
     pub fn try_new_from_string(
         content: impl Into<String>,
         vars: &[(&str, &str)],
-    ) -> crate::Result<Self> {
+    ) -> crate::Result<(Self, String)> {
         let content = apply_vars(content.into(), vars);
         let seq = serde_json::from_str(&content)?;
 
-        Ok(seq)
+        Ok((seq, content))
     }
 
     pub fn should_handle(&self, p: &TypedPrompt) -> bool {

--- a/prompting-client/tests/integration.rs
+++ b/prompting-client/tests/integration.rs
@@ -421,7 +421,7 @@ async fn scripted_client_works_with_simple_matching() -> Result<()> {
     let (prefix, dir_path) = setup_test_dir(None, &[("seq.json", seq)])?;
 
     let _rx = spawn_for_output("aa-prompting-test.create", vec![prefix]);
-    let res = run_scripted_client_loop(&mut c, format!("{dir_path}/seq.json"), None).await;
+    let res = run_scripted_client_loop(&mut c, format!("{dir_path}/seq.json"), &[], None).await;
     sleep(Duration::from_millis(50)).await;
 
     if let Err(e) = res {
@@ -450,7 +450,13 @@ async fn invalid_prompt_sequence_reply_errors() -> Result<()> {
     let (prefix, dir_path) = setup_test_dir(None, &[("seq.json", seq)])?;
 
     spawn_for_output("aa-prompting-test.create", vec![prefix]);
-    let res = run_scripted_client_loop(&mut c, format!("{dir_path}/seq.json"), None).await;
+    let res = run_scripted_client_loop(
+        &mut c,
+        format!("{dir_path}/seq.json"),
+        &[("BASE_PATH", &dir_path)],
+        None,
+    )
+    .await;
 
     match res {
         Err(Error::FailedPromptSequence {
@@ -478,7 +484,13 @@ async fn unexpected_prompt_in_sequence_errors() -> Result<()> {
     let (prefix, dir_path) = setup_test_dir(None, &[("seq.json", seq)])?;
 
     spawn_for_output("aa-prompting-test.create", vec![prefix]);
-    let res = run_scripted_client_loop(&mut c, format!("{dir_path}/seq.json"), None).await;
+    let res = run_scripted_client_loop(
+        &mut c,
+        format!("{dir_path}/seq.json"),
+        &[("BASE_PATH", &dir_path)],
+        None,
+    )
+    .await;
 
     match res {
         Err(Error::FailedPromptSequence {
@@ -505,7 +517,13 @@ async fn prompt_after_a_sequence_with_grace_period_errors() -> Result<()> {
     let (prefix, dir_path) = setup_test_dir(None, &[("seq.json", seq)])?;
 
     let _rx = spawn_for_output("aa-prompting-test.create", vec![prefix]);
-    let res = run_scripted_client_loop(&mut c, format!("{dir_path}/seq.json"), Some(5)).await;
+    let res = run_scripted_client_loop(
+        &mut c,
+        format!("{dir_path}/seq.json"),
+        &[("BASE_PATH", &dir_path)],
+        Some(5),
+    )
+    .await;
 
     match res {
         Err(Error::FailedPromptSequence {
@@ -526,7 +544,13 @@ async fn prompt_after_a_sequence_without_grace_period_is_ok() -> Result<()> {
     let (prefix, dir_path) = setup_test_dir(None, &[("seq.json", seq)])?;
 
     let _rx = spawn_for_output("aa-prompting-test.create", vec![prefix]);
-    let res = run_scripted_client_loop(&mut c, format!("{dir_path}/seq.json"), None).await;
+    let res = run_scripted_client_loop(
+        &mut c,
+        format!("{dir_path}/seq.json"),
+        &[("BASE_PATH", &dir_path)],
+        None,
+    )
+    .await;
 
     // Sleep to create a gap between this test and the next so that the outstanding prompts do not
     // get picked up as part of that test. Without this we are racey around what the first prompt


### PR DESCRIPTION
- Support specifying a top level filter to limit what prompts the sequence attempts to match against
- Support specifying and using variables to allow for passing per-run specific data (e.g. a temp directory)

See the updated sequence JSON files for examples of how this looks in practice.

A full example "spread" test for a happy path read can be written as follows:
```bash
#!/usr/bin/env sh

PREFIX="$1"
TEST_DIR="/home/ubuntu/test/$PREFIX"

prompting-client.scripted \
  --script="$TEST_DIR/prompt-sequence.json" \
  --var "BASE_PATH:$TEST_DIR" | tee "$TEST_DIR/outfile" &

# Ensure that the test client is already listening
sleep 0.2
TEST_OUTPUT="$(aa-prompting-test.read "$PREFIX")"

# Ensure that the test client has time to write its output
# For tests with a grace period this will need to be taken into account as well
sleep 0.2
CLIENT_OUTPUT="$(cat "$TEST_DIR/outfile")"

if [ "$CLIENT_OUTPUT" != "success" ]; then
  echo "test failed"
  echo "output='$CLIENT_OUTPUT'"
  exit 1
fi

if [ "$TEST_OUTPUT" != "testing testing 1 2 3" ]; then
  echo "test script failed"
  exit 1
fi
```

# Example output

I'm not sure what to make about this error that I see from `update.go` @olivercalder? I'm assuming it is coming from snapd but I'm not sure why it shows up here in the output from running the scripted client...

Output when a sequence succeeds:
```
running 1 test
update.go:85: cannot change mount namespace according to change mount (/run/user/1000/doc/by-app/snap.prompting-client /run/user/1000/doc none bind,rw,x-snapd.ignore-missing 0 0): cannot inspect "/run/user/1000/doc": lstat /run/user/1000/doc: permission denied
creating client
script path: /home/ubuntu/test/edffdcfd-6f11-4dbd-947b-77c839cce0fa/prompt-sequence.json
success
test scripted_client_test_allow ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 28 filtered out; finished in 0.47s
```

Output when a sequence fails:
```
running 1 test
update.go:85: cannot change mount namespace according to change mount (/run/user/1000/doc/by-app/snap.prompting-client /run/user/1000/doc none bind,rw,x-snapd.ignore-missing 0 0): cannot inspect "/run/user/1000/doc": lstat /run/user/1000/doc: permission denied
creating client
script path: /home/ubuntu/test/e61b1d06-8cbb-41b0-9cb2-2aedba30e4c1/prompt-sequence.json
failed prompt sequence: prompt 0 did not match the provided sequence: [MatchFailure { field: "requested_permissions", expected: "[\"write\"]", seen: "[\"read\"]" }]

script: {
  "version": 1,
  "prompt-filter": {
    "snap": "aa-prompting-test",
    "interface": "home",
    "constraints": {
      "path": "/home/ubuntu/test/e61b1d06-8cbb-41b0-9cb2-2aedba30e4c1/.*"
    }
  },
  "prompts": [
    {
      "prompt-filter": {
        "constraints": {
          "path": ".*/test.txt",
          "requested-permissions": [ "write" ]
        }
      },
      "reply": {
        "action": "allow",
        "lifespan": "single",
        "constraints": {
          "path-pattern": "/home/ubuntu/test/e61b1d06-8cbb-41b0-9cb2-2aedba30e4c1/test.txt",
          "permissions": [ "read" ]
        }
      }
    }
  ]
}
```