### PR TITLE
fix(prompting-client): fix home pattern generation when home is not under /home

### DIFF
--- a/prompting-client/src/lib.rs
+++ b/prompting-client/src/lib.rs
@@ -56,6 +56,9 @@ pub enum Error {
         available: Vec<String>,
     },
 
+    #[error("snapd provided a home interface prompt for a path outside of home: path={path:?} but home={home:?}")]
+    InvalidHomePromptPath { path: String, home: String },
+
     #[error("{version} is not supported recording version.")]
     InvalidRecordingVersion { version: u8 },
 

--- a/prompting-client/src/recording.rs
+++ b/prompting-client/src/recording.rs
@@ -85,26 +85,6 @@ impl PromptRecording {
         }
     }
 
-    pub fn push_ui_input(&mut self, data: serde_json::Value) {
-        if self.is_recording() {
-            self.events.push(Event::UiInput { data });
-        }
-    }
-
-    pub fn push_reply(&mut self, r: &TypedPromptReply) {
-        if self.is_recording() {
-            self.events.push(Event::Reply { data: r.clone() })
-        }
-    }
-
-    pub fn push_error(&mut self, err: &Error) {
-        if self.is_recording() {
-            self.events.push(Event::Error {
-                data: err.to_string(),
-            })
-        }
-    }
-
     pub async fn await_update_handling_ctrl_c(
         &self,
         rx_prompts: &mut UnboundedReceiver<PromptUpdate>,

--- a/prompting-client/src/snapd_client/interfaces/home.rs
+++ b/prompting-client/src/snapd_client/interfaces/home.rs
@@ -70,8 +70,8 @@ impl PatternOptions {
     ///
     /// Details of the cases and rationale behind how we handle this can be found here:
     ///   https://www.figma.com/board/1DIGbaCf4ZjTcShYjLiAIi/24.10-AppArmor-prompting---MVP-logic?node-id=0-1&t=4kUtDaqmQEvLA8v7-0
-    fn new(path: &str, home_dir: &str) -> Self {
-        let cpath = CategorisedPath::from_path(path);
+    fn new(path: &str, home_dir: &str) -> Result<Self> {
+        let cpath = CategorisedPath::from_path(path, home_dir)?;
 
         let mut options = vec![TypedPathPattern::after_more_options(
             PatternType::HomeDirectory,
@@ -93,15 +93,15 @@ impl PatternOptions {
         options.push(cpath.requested_path_pattern());
 
         if !cpath.is_dir {
-            if let Some(opt) = cpath.matching_extension_pattern(home_dir) {
+            if let Some(opt) = cpath.matching_extension_pattern() {
                 options.push(opt);
             }
         }
 
-        Self {
+        Ok(Self {
             initial_pattern_option: 1,
             pattern_options: options,
-        }
+        })
     }
 }
 
@@ -110,7 +110,7 @@ fn home_dir_from_env() -> String {
 }
 
 impl HomeInterface {
-    fn ui_options(&self, prompt: &Prompt<Self>) -> PatternOptions {
+    fn ui_options(&self, prompt: &Prompt<Self>) -> Result<PatternOptions> {
         let path = &prompt.constraints.path;
         PatternOptions::new(path, &home_dir_from_env())
     }
@@ -141,11 +141,11 @@ impl SnapInterface for HomeInterface {
         }
     }
 
-    fn map_ui_input(&self, prompt: Prompt<Self>, meta: Option<SnapMeta>) -> UiInput<Self> {
+    fn map_ui_input(&self, prompt: Prompt<Self>, meta: Option<SnapMeta>) -> Result<UiInput<Self>> {
         let PatternOptions {
             initial_pattern_option,
             pattern_options,
-        } = self.ui_options(&prompt);
+        } = self.ui_options(&prompt)?;
         let meta = meta.unwrap_or_else(|| SnapMeta {
             name: prompt.snap,
             updated_at: String::default(),
@@ -161,7 +161,7 @@ impl SnapInterface for HomeInterface {
             initial_permissions.push("read".to_string());
         }
 
-        UiInput {
+        Ok(UiInput {
             id: prompt.id,
             meta,
             data: HomeUiInputData {
@@ -173,7 +173,7 @@ impl SnapInterface for HomeInterface {
                 pattern_options,
                 initial_pattern_option,
             },
-        }
+        })
     }
 
     fn map_ui_reply(&self, reply: Self::UiReply) -> PromptReply<Self> {
@@ -343,33 +343,52 @@ impl ReplyConstraintsOverrides for HomeReplyConstraintsOverrides {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CategorisedPath<'a> {
     raw_path: &'a str,
+    home_dir: &'a str,
     path: PathBuf,
     is_dir: bool,
 }
 
 impl<'a> CategorisedPath<'a> {
-    fn from_path(path: &'a str) -> Self {
-        let is_dir = path.ends_with('/');
+    fn from_path(raw_path: &'a str, home_dir: &'a str) -> Result<Self> {
+        let is_dir = raw_path.ends_with('/');
+        let path = match PathBuf::from(raw_path).strip_prefix(home_dir) {
+            Ok(path) => path.to_path_buf(),
+            Err(_) => {
+                return Err(Error::InvalidHomePromptPath {
+                    path: raw_path.to_string(),
+                    home: home_dir.to_string(),
+                })
+            }
+        };
 
-        Self {
-            raw_path: path,
-            path: PathBuf::from(path),
+        Ok(Self {
+            raw_path,
+            home_dir,
+            path,
             is_dir,
-        }
+        })
     }
 
     fn is_home_dir_or_top_level_file(&self) -> bool {
         let n_segments = self.path.iter().count();
 
-        n_segments == 3 || (n_segments == 4 && !self.is_dir)
+        n_segments == 0 || (n_segments == 1 && !self.is_dir)
     }
 
     fn is_nested_file(&self) -> bool {
-        self.path.iter().count() > 5 && !self.is_dir
+        if self.is_dir {
+            return false;
+        }
+
+        self.path.iter().count() > 2
     }
 
     fn is_sub_dir(&self) -> bool {
-        self.path.iter().count() > 4 && self.is_dir
+        if !self.is_dir {
+            return false;
+        }
+
+        self.path.iter().count() > 1
     }
 
     fn requested_path_pattern(&self) -> TypedPathPattern {
@@ -386,11 +405,11 @@ impl<'a> CategorisedPath<'a> {
 
     fn top_level_dir_pattern(&self) -> TypedPathPattern {
         debug_assert!(!self.is_home_dir_or_top_level_file());
-        let top_level: PathBuf = self.path.iter().take(4).collect();
+        let top_level: PathBuf = self.path.iter().take(1).collect();
 
         TypedPathPattern::initial(
             PatternType::TopLevelDirectory,
-            format!("{}/**", top_level.to_string_lossy()),
+            format!("{}/{}/**", self.home_dir, top_level.to_string_lossy()),
         )
     }
 
@@ -402,7 +421,7 @@ impl<'a> CategorisedPath<'a> {
 
         TypedPathPattern::initial(
             PatternType::ContainingDirectory,
-            format!("{}/**", pb.to_string_lossy()),
+            format!("{}/{}/**", self.home_dir, pb.to_string_lossy()),
         )
     }
 
@@ -415,14 +434,14 @@ impl<'a> CategorisedPath<'a> {
         )
     }
 
-    fn matching_extension_pattern(&self, home_dir: &str) -> Option<TypedPathPattern> {
+    fn matching_extension_pattern(&self) -> Option<TypedPathPattern> {
         debug_assert!(!self.is_dir);
         match self.path.extension() {
             Some(ext) => {
                 let ext = ext.to_string_lossy();
                 Some(TypedPathPattern::after_more_options(
                     PatternType::MatchingFileExtension,
-                    format!("{home_dir}/**/*.{ext}"),
+                    format!("{}/**/*.{ext}", self.home_dir),
                 ))
             }
             _ => None,
@@ -494,47 +513,97 @@ mod tests {
         }
     }
 
+    #[test_case("/home/user"; "default home")]
+    #[test_case("/mnt"; "non standard home short")]
+    #[test_case("/non/standard/home/user"; "non standard home long")]
     #[test]
-    fn dir_contents_pattern_works() {
-        let cpath = CategorisedPath::from_path("/home/user/Documents/banking/");
-        let patt = cpath.dir_contents_pattern();
-        assert_eq!(patt.path_pattern, "/home/user/Documents/banking/**");
+    fn top_level_dir_pattern_works(home_dir: &str) {
+        let full_path = format!("{home_dir}/Documents/notes/");
+        let cpath = CategorisedPath::from_path(&full_path, home_dir).unwrap();
+        let patt = cpath.top_level_dir_pattern();
+        assert_eq!(patt.path_pattern, format!("{home_dir}/Documents/**"));
     }
 
-    #[test_case("/home/user/", false; "home dir")]
-    #[test_case("/home/user/foo.txt", false; "top level file")]
-    #[test_case("/home/user/Documents/", false; "top level dir")]
-    #[test_case("/home/user/Documents/foo/bar.txt", true; "nested file")]
-    #[test_case("/home/user/Documents/banking/", false; "nested dir")]
-    #[test_case("/home/user/Documents/foo.txt", false; "file in top level dir")]
+    #[test_case("/home/user"; "default home")]
+    #[test_case("/mnt"; "non standard home short")]
+    #[test_case("/non/standard/home/user"; "non standard home long")]
+    #[test]
+    fn containing_dir_pattern_works(home_dir: &str) {
+        let full_path = format!("{home_dir}/Documents/notes/todo.md");
+        let cpath = CategorisedPath::from_path(&full_path, home_dir).unwrap();
+        let patt = cpath.containing_dir_pattern();
+        assert_eq!(patt.path_pattern, format!("{home_dir}/Documents/notes/**"));
+    }
+
+    #[test_case("/home/user"; "default home")]
+    #[test_case("/mnt"; "non standard home short")]
+    #[test_case("/non/standard/home/user"; "non standard home long")]
+    #[test]
+    fn dir_contents_pattern_works(home_dir: &str) {
+        let full_path = format!("{home_dir}/Documents/notes/");
+        let cpath = CategorisedPath::from_path(&full_path, home_dir).unwrap();
+        let patt = cpath.dir_contents_pattern();
+        assert_eq!(patt.path_pattern, format!("{full_path}**"));
+    }
+
+    #[test_case("/home/user"; "default home")]
+    #[test_case("/mnt"; "non standard home short")]
+    #[test_case("/non/standard/home/user"; "non standard home long")]
+    #[test]
+    fn matching_extension_pattern_works(home_dir: &str) {
+        let full_path = format!("{home_dir}/Documents/notes/todo.md");
+        let cpath = CategorisedPath::from_path(&full_path, home_dir).unwrap();
+        let patt = cpath.matching_extension_pattern().unwrap();
+        assert_eq!(patt.path_pattern, format!("{home_dir}/**/*.md"));
+    }
+
+    #[test_case("", false; "home dir")]
+    #[test_case("foo.txt", false; "top level file")]
+    #[test_case("Documents/", false; "top level dir")]
+    #[test_case("Documents/foo/bar.txt", true; "nested file")]
+    #[test_case("Documents/notes/", false; "nested dir")]
+    #[test_case("Documents/foo.txt", false; "file in top level dir")]
     #[test]
     fn is_nested_file(path: &str, expected: bool) {
-        let cpath = CategorisedPath::from_path(path);
-        assert_eq!(cpath.is_nested_file(), expected);
+        for home_dir in ["/home/user", "/mnt", "/non/standard/home/user"] {
+            let full_path = format!("{home_dir}/{path}");
+            let cpath = CategorisedPath::from_path(&full_path, home_dir).unwrap();
+            assert_eq!(cpath.is_nested_file(), expected, "home is {home_dir}");
+        }
     }
 
-    #[test_case("/home/user/", false; "home dir")]
-    #[test_case("/home/user/foo.txt", false; "top level file")]
-    #[test_case("/home/user/Documents/", false; "top level dir")]
-    #[test_case("/home/user/Documents/foo/bar.txt", false; "nested file")]
-    #[test_case("/home/user/Documents/banking/", true; "nested dir")]
-    #[test_case("/home/user/Documents/foo.txt", false; "file in top level dir")]
+    #[test_case("", false; "home dir")]
+    #[test_case("foo.txt", false; "top level file")]
+    #[test_case("Documents/", false; "top level dir")]
+    #[test_case("Documents/foo/bar.txt", false; "nested file")]
+    #[test_case("Documents/notes/", true; "nested dir")]
+    #[test_case("Documents/foo.txt", false; "file in top level dir")]
     #[test]
     fn is_sub_dir(path: &str, expected: bool) {
-        let cpath = CategorisedPath::from_path(path);
-        assert_eq!(cpath.is_sub_dir(), expected);
+        for home_dir in ["/home/user", "/mnt", "/non/standard/home/user"] {
+            let full_path = format!("{home_dir}/{path}");
+            let cpath = CategorisedPath::from_path(&full_path, home_dir).unwrap();
+            assert_eq!(cpath.is_sub_dir(), expected, "home is {home_dir}");
+        }
     }
 
-    #[test_case("/home/user/", true; "home dir")]
-    #[test_case("/home/user/foo.txt", true; "top level file")]
-    #[test_case("/home/user/Documents/", false; "top level dir")]
-    #[test_case("/home/user/Documents/foo.txt", false; "nested file")]
-    #[test_case("/home/user/Documents/banking/", false; "nested dir")]
-    #[test_case("/home/user/Documents/foo.txt", false; "file in top level dir")]
+    #[test_case("", true; "home dir")]
+    #[test_case("foo.txt", true; "top level file")]
+    #[test_case("Documents/", false; "top level dir")]
+    #[test_case("Documents/foo.txt", false; "nested file")]
+    #[test_case("Documents/notes/", false; "nested dir")]
+    #[test_case("Documents/foo.txt", false; "file in top level dir")]
     #[test]
     fn is_home_dir_or_top_level_file(path: &str, expected: bool) {
-        let cpath = CategorisedPath::from_path(path);
-        assert_eq!(cpath.is_home_dir_or_top_level_file(), expected);
+        for home_dir in ["/home/user", "/mnt", "/non/standard/home/user"] {
+            let full_path = format!("{home_dir}/{path}");
+            let cpath = CategorisedPath::from_path(&full_path, home_dir).unwrap();
+            assert_eq!(
+                cpath.is_home_dir_or_top_level_file(),
+                expected,
+                "home is {home_dir}"
+            );
+        }
     }
 
     #[test_case(
@@ -636,15 +705,26 @@ mod tests {
         initial_pattern_option: usize,
         expected: &[(PatternType, bool)],
     ) {
-        let p = PatternOptions::new(path, "/home/user");
-        assert_eq!(p.initial_pattern_option, initial_pattern_option);
+        for (full_path, home_dir) in [
+            (path, "/home/user"),
+            (&format!("/non/standard{path}"), "/non/standard/home/user"),
+        ] {
+            let p = PatternOptions::new(full_path, home_dir).unwrap();
+            assert_eq!(
+                p.initial_pattern_option, initial_pattern_option,
+                "initial pattern option with home_dir={home_dir}"
+            );
 
-        let descriptions: Vec<(PatternType, bool)> = p
-            .pattern_options
-            .iter()
-            .map(|pd| (pd.pattern_type, pd.show_initially))
-            .collect();
+            let options: Vec<(PatternType, bool)> = p
+                .pattern_options
+                .iter()
+                .map(|pd| (pd.pattern_type, pd.show_initially))
+                .collect();
 
-        assert_eq!(descriptions, expected);
+            assert_eq!(
+                options, expected,
+                "options with default home_dir={home_dir}"
+            );
+        }
     }
 }

--- a/prompting-client/src/snapd_client/interfaces/home.rs
+++ b/prompting-client/src/snapd_client/interfaces/home.rs
@@ -194,19 +194,6 @@ impl SnapInterface for HomeInterface {
             },
         })
     }
-
-    fn map_ui_reply(&self, reply: Self::UiReply) -> PromptReply<Self> {
-        PromptReply {
-            action: reply.action,
-            lifespan: reply.lifespan,
-            duration: None,
-            constraints: HomeReplyConstraints {
-                path_pattern: reply.path_pattern,
-                permissions: reply.permissions,
-                available_permissions: Vec::new(),
-            },
-        }
-    }
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/prompting-client/src/snapd_client/interfaces/mod.rs
+++ b/prompting-client/src/snapd_client/interfaces/mod.rs
@@ -30,8 +30,6 @@ pub trait SnapInterface: fmt::Debug + Clone {
     fn prompt_to_reply(prompt: Prompt<Self>, action: Action) -> PromptReply<Self>;
 
     fn map_ui_input(&self, prompt: Prompt<Self>, meta: Option<SnapMeta>) -> Result<UiInput<Self>>;
-
-    fn map_ui_reply(&self, reply: Self::UiReply) -> PromptReply<Self>;
 }
 
 pub trait ConstraintsFilter: Default + fmt::Debug + Clone + Serialize + DeserializeOwned {

--- a/prompting-client/src/snapd_client/interfaces/mod.rs
+++ b/prompting-client/src/snapd_client/interfaces/mod.rs
@@ -2,14 +2,11 @@
 //! prompts for it and how we generate the UI for the user.
 use crate::{
     prompt_sequence::MatchAttempt,
-    recording::PromptRecording,
     snapd_client::{Action, Prompt, PromptReply},
     Result,
 };
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt;
-use tokio::process::Command;
-use tracing::debug;
 
 use super::{prompt::UiInput, SnapMeta};
 
@@ -32,43 +29,9 @@ pub trait SnapInterface: fmt::Debug + Clone {
 
     fn prompt_to_reply(prompt: Prompt<Self>, action: Action) -> PromptReply<Self>;
 
-    fn map_ui_input(&self, prompt: Prompt<Self>, meta: Option<SnapMeta>) -> UiInput<Self>;
+    fn map_ui_input(&self, prompt: Prompt<Self>, meta: Option<SnapMeta>) -> Result<UiInput<Self>>;
 
     fn map_ui_reply(&self, reply: Self::UiReply) -> PromptReply<Self>;
-
-    async fn try_get_reply_from_ui(
-        &self,
-        cmd: &str,
-        prompt: Prompt<Self>,
-        meta: Option<SnapMeta>,
-        rec: &mut PromptRecording,
-    ) -> Result<PromptReply<Self>> {
-        let input = self.map_ui_input(prompt.clone(), meta);
-        let json_input = serde_json::to_value(&input)?;
-        debug!(%json_input, "prompt details for the flutter ui");
-
-        let output = Command::new(cmd)
-            .arg(json_input.to_string())
-            .output()
-            .await?;
-
-        debug!(
-            raw_stdout = %String::from_utf8(output.stdout.clone()).unwrap(),
-            "raw output from the flutter ui"
-        );
-        rec.push_ui_input(json_input);
-
-        // If the user closes out the prompt without submitting a reply we will get nothing on
-        // stdout so we treat that as "deny once".
-        if output.stdout.is_empty() {
-            return Ok(Self::prompt_to_reply(prompt, Action::Deny));
-        }
-
-        let ui_reply: Self::UiReply = serde_json::from_slice(&output.stdout)?;
-        debug!(?ui_reply, "parsed reply from the flutter ui");
-
-        Ok(self.map_ui_reply(ui_reply))
-    }
 }
 
 pub trait ConstraintsFilter: Default + fmt::Debug + Clone + Serialize + DeserializeOwned {

--- a/prompting-client/src/snapd_client/prompt.rs
+++ b/prompting-client/src/snapd_client/prompt.rs
@@ -195,9 +195,10 @@ impl TypedUiInput {
         &input.id
     }
 
-    pub fn from_prompt(prompt: TypedPrompt, meta: Option<SnapMeta>) -> Self {
+    pub fn try_from_prompt(prompt: TypedPrompt, meta: Option<SnapMeta>) -> Result<Self> {
         let TypedPrompt::Home(p) = prompt;
-        Self::Home(HomeInterface.map_ui_input(p, meta))
+
+        Ok(Self::Home(HomeInterface.map_ui_input(p, meta)?))
     }
 }
 


### PR DESCRIPTION
The helper methods used for determining which category of path we are generating options for implicitly assumes that the user’s home directory is located in /home. This has the potential to generate invalid options or possibly hard error in the generation of options if the user has set their home directory to be somewhere else.

We now take the value of `$SNAP_REAL_HOME` into account when generating the options rather than assuming the standard home directory location.

I've also tidied up the method that generates the options to make it easier to read exactly which options will be provided in each of the cases outlined in @juanruitina's Figma design.

---

One interesting side effect of sorting this out is that it has highlighted that we have a very odd (but I think technically possible?) failure mode: in principal we can get a home interface prompt from snapd that is for a path not under `$SNAP_REAL_HOME`. I don't think that we should ever hit this in practice, but nothing in the way the prompt details are provided from snapd prevents this so we need to account for it. For now I'm error logging and sending a deny once rather than attempting to serve the prompt as there is no way for us to sensibly generate the required options in this case.

@olivercalder tagging you in case you have any thoughts on this one!