### PR TITLE
feat: reveal custom path text field on error

### DIFF
--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_data_model.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_data_model.dart
@@ -117,7 +117,14 @@ class HomePromptDataModel extends _$HomePromptDataModel {
     final response = await getService<PromptingClient>()
         .replyToPrompt(buildReply(action: action, lifespan: lifespan));
     if (response is PromptReplyResponseUnknown) {
-      state = state.copyWith(errorMessage: response.message);
+      state = state.copyWith(
+        errorMessage: response.message,
+        showMoreOptions: true,
+        patternOption: PatternOption(
+          homePatternType: HomePatternType.customPath,
+          pathPattern: '',
+        ),
+      );
     }
     return response;
   }

--- a/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -490,4 +490,26 @@ void main() {
 
     expect(find.text('error message'), findsNothing);
   });
+
+  testWidgets('reveal custom path text field on error', (tester) async {
+    final container = createContainer();
+    registerMockPromptDetails(
+      promptDetails: testDetails,
+    );
+    registerMockAppArmorPromptingClient(
+      promptDetails: testDetails,
+      replyResponse: PromptReplyResponse.unknown(message: 'error message'),
+    );
+    await tester.pumpApp(
+      (_) => UncontrolledProviderScope(
+        container: container,
+        child: const PromptPage(),
+      ),
+    );
+
+    await tester.tap(find.text(tester.l10n.promptActionOptionAllowAlways));
+    await tester.pumpAndSettle();
+
+    expect(find.text('error message'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Currently the UI expects the grpc server to only reply with an error status when sending a reply with a custom path pattern, so the corresponding error message is displayed as a validation string for the text field.
However, it is possible that we receive errors for simpler replies as well, and we should display those properly in the UI. As a workaround, this PR simply ensures that the 'custom path' option gets selected and the text field is revealed, if the server returns an error.

[Screencast from 2024-09-20 12-39-55.webm](https://github.com/user-attachments/assets/3ae6edb7-2af1-44bf-8c18-6522065825aa)
