### PR TITLE
fix: set minimum window width

### DIFF
--- a/flutter_packages/prompting_client_ui/lib/prompt_page.dart
+++ b/flutter_packages/prompting_client_ui/lib/prompt_page.dart
@@ -39,11 +39,14 @@ class PromptPage extends ConsumerWidget {
             }
 
             return SizeChangedLayoutNotifier(
-              child: Padding(
-                padding: const EdgeInsets.all(18.0),
-                child: switch (prompt) {
-                  PromptDetailsHome() => const HomePromptPage(),
-                },
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(minWidth: 560),
+                child: Padding(
+                  padding: const EdgeInsets.all(18.0),
+                  child: switch (prompt) {
+                    PromptDetailsHome() => const HomePromptPage(),
+                  },
+                ),
               ),
             );
           },


### PR DESCRIPTION
Fixes a bug where the prompt window flickers due to multiple successive resizes caused by overflowing widgets when the (horizontally expanding) metadata dropdown is missing:

Before:

[Screencast from 2024-09-20 15-26-41.webm](https://github.com/user-attachments/assets/6d83c115-63a0-4169-be20-954770334337)

After:

[Screencast from 2024-09-20 15-27-08.webm](https://github.com/user-attachments/assets/2f0aec51-2a0c-4fe9-9664-d81887a4a71b)

