### PR TITLE
feat: use `bodyMedium` font size for titles

### DIFF
--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_page.dart
@@ -308,6 +308,7 @@ class _CustomPathTextField extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         TextFormField(
+          style: Theme.of(context).textTheme.bodyMedium,
           initialValue: customPath,
           onChanged: notifier.setCustomPath,
           decoration: InputDecoration(

--- a/flutter_packages/prompting_client_ui/lib/main.dart
+++ b/flutter_packages/prompting_client_ui/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:prompting_client/prompting_client.dart';
 import 'package:prompting_client_ui/fake_prompting_client.dart';
 import 'package:prompting_client_ui/l10n.dart';
 import 'package:prompting_client_ui/prompt_page.dart';
+import 'package:prompting_client_ui/theme.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru/yaru.dart';
@@ -77,8 +78,8 @@ class PromptDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return YaruTheme(
       builder: (context, yaru, child) => MaterialApp(
-        theme: yaru.theme,
-        darkTheme: yaru.darkTheme,
+        theme: yaru.theme?.customize(),
+        darkTheme: yaru.darkTheme?.customize(),
         debugShowCheckedModeBanner: false,
         localizationsDelegates: localizationsDelegates,
         supportedLocales: supportedLocales,

--- a/flutter_packages/prompting_client_ui/lib/theme.dart
+++ b/flutter_packages/prompting_client_ui/lib/theme.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
+
+extension ThemeDataX on ThemeData {
+  ThemeData customize() {
+    return copyWith(
+      extensions: [
+        YaruToggleButtonThemeData(titleStyle: textTheme.bodyMedium),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Reduces the text sizes of the radio/checkbox titles and the custom path text field as suggested by @juanruitina.

![image](https://github.com/user-attachments/assets/634d355f-fc85-4be9-85bd-4e51d384c29a)

UDENG-4608
