### PR TITLE
feat: checking for last-data in notices from snapd

### DIFF
--- a/prompting-client/src/snapd_client/prompt.rs
+++ b/prompting-client/src/snapd_client/prompt.rs
@@ -205,6 +205,22 @@ impl TypedUiInput {
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PromptId(pub String);
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub enum PromptNotice {
+    Update(PromptId),
+    Resolved(PromptId),
+}
+
+impl PromptNotice {
+    /// Flatten this notice into the enclosed ID if it was an update
+    pub fn into_option_id(self) -> Option<PromptId> {
+        match self {
+            Self::Update(id) => Some(id),
+            _ => None,
+        }
+    }
+}
+
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Display, EnumString,
 )]

--- a/prompting-client/src/snapd_client/prompt.rs
+++ b/prompting-client/src/snapd_client/prompt.rs
@@ -211,16 +211,6 @@ pub enum PromptNotice {
     Resolved(PromptId),
 }
 
-impl PromptNotice {
-    /// Flatten this notice into the enclosed ID if it was an update
-    pub fn into_option_id(self) -> Option<PromptId> {
-        match self {
-            Self::Update(id) => Some(id),
-            _ => None,
-        }
-    }
-}
-
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Display, EnumString,
 )]

--- a/prompting-client/tests/integration.rs
+++ b/prompting-client/tests/integration.rs
@@ -11,7 +11,7 @@ use prompting_client::{
     prompt_sequence::MatchError,
     snapd_client::{
         interfaces::{home::HomeInterface, SnapInterface},
-        Action, Lifespan, PromptId, SnapdSocketClient, TypedPrompt,
+        Action, Lifespan, PromptId, PromptNotice, SnapdSocketClient, TypedPrompt,
     },
     Error, Result,
 };
@@ -80,7 +80,10 @@ macro_rules! expect_single_prompt {
             let mut pending: Vec<_> = match $c.pending_prompt_notices().await {
                 Ok(pending) => pending
                     .into_iter()
-                    .flat_map(|n| n.into_option_id())
+                    .flat_map(|n| match n {
+                        PromptNotice::Update(id) => Some(id),
+                        _ => None,
+                    })
                     .collect(),
                 Err(e) => panic!("error pulling pending prompts: {e}"),
             };

--- a/prompting-client/tests/integration.rs
+++ b/prompting-client/tests/integration.rs
@@ -77,8 +77,11 @@ fn setup_test_dir(subdir: Option<&str>, files: &[(&str, &str)]) -> io::Result<(S
 macro_rules! expect_single_prompt {
     ($c:expr, $expected_path:expr, $expected_permissions:expr) => {
         async {
-            let mut pending = match $c.pending_prompt_ids().await {
-                Ok(pending) => pending,
+            let mut pending: Vec<_> = match $c.pending_prompt_notices().await {
+                Ok(pending) => pending
+                    .into_iter()
+                    .flat_map(|n| n.into_option_id())
+                    .collect(),
                 Err(e) => panic!("error pulling pending prompts: {e}"),
             };
             assert_eq!(pending.len(), 1, "expected a single prompt");


### PR DESCRIPTION
The data we get from the snapd notices endpoint now supports an optional `last-data` field which we can use to be a little more efficient in how we pull prompt details.
```
    {
      "id": "1674",
      "user-id": 1000,
      "type": "interfaces-requests-prompt",
      "key": "000000000000014E",
      "first-occurred": "2024-09-13T13:05:05.189006863Z",
      "last-occurred": "2024-09-13T13:05:05.232809028Z",
      "last-repeated": "2024-09-13T13:05:05.232809028Z",
      "occurrences": 2,
      "last-data": {
        "resolved": "replied"
      },
      "expire-after": "168h0m0s"
    }
```

In the case where we get a notice with `last-data.resolved == "replied"` we can treat this in the same way we currently treat getting a 404 when pulling prompt details (i.e. removing our internal state for that prompt).