### PR TITLE
feat: Scripted client nullable replies

### DIFF
--- a/docs/running-the-scripted-client.md
+++ b/docs/running-the-scripted-client.md
@@ -54,6 +54,16 @@ A prompt sequence is a simple JSON file with the following structure:
         }
       }
     },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/example.txt",
+          "permissions": [ "read" ],
+          "available-permissions": [ "read", "write", "execute" ]
+        }
+      },
+      "reply": null
+    }
     ...
   ]
 }
@@ -89,7 +99,7 @@ but if you do then all prompts not matching it will be ignored by the scripted c
 See the `Prompt filter fields` section below for specific details on each of the
 supported fields for a filter.
 
-### Prompts
+### Prompt cases
 A sequence of prompt cases: a prompt filter allowing for structural matching
 against the next prompt in the sequence along with a template for build the
 reply to that prompt provided the filter matches. If the filter does not match
@@ -116,7 +126,13 @@ prompts the following fields are available:
 - `available-permissions`: the ordered list of available permissions seen in the prompt
 
 ### Reply templates
-The only required fields for a reply template are the `action` (allow or deny)
+If you wish the client to send a reply for a particular prompt then you should provide
+a reply template under the `reply` field of prompt case. This is the expected default
+behaviour of the client. In order to expect that a certain prompt be observed as part
+of the sequence but _not_ send a reply you must explicitly provide `"reply": null`
+rather than simply omitting the key.
+
+When providing a reply template, the only required fields are the `action` (allow or deny)
 and `lifespan` (single, session, forever or timespan). If `lifespan` is set to
 timespan then the optional `duration` field must also be provided.
 

--- a/prompting-client/resources/prompt-sequence-tests/sequence_without_replies.json
+++ b/prompting-client/resources/prompt-sequence-tests/sequence_without_replies.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "prompts": [
+    {
+      "prompt-filter": {
+        "snap": "testSnap",
+        "interface": "home",
+        "constraints": {
+          "path": "/home/foo/bar",
+          "requested-permissions": [ "read" ],
+          "available-permissions": [ "read", "write", "execute" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "/home/foo/bar",
+          "permissions": [ "read", "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "snap": "testSnap",
+        "interface": "home",
+        "constraints": {
+          "path": "/home/foo/bar",
+          "requested-permissions": [ "read" ],
+          "available-permissions": [ "read", "write", "execute" ]
+        }
+      },
+      "reply": null
+    }
+  ]
+}


### PR DESCRIPTION
Support not replying to every prompt in a scripted client prompt-sequence.

Currently, prompting-client.scripted accepts scripts which have a top-level "prompt-filter" and a "prompts" list, which is a list of json objects with two mandatory fields: "prompt-filter" and "reply". The scripted client expects relevant prompts to match the filters specified in the "prompts" list in order, and for each one, immediately sends back the accompanying reply.

However, to write a spread test which mimics the `create_multiple_actioned_by_other_pid` integration test, we need to be able to attempt multiple writes (and check that those attempts occurred as expected), and then on a subsequent attempt, reply with a rule which then actions the previous prompts as well.

The docs update and new test data cover the new supported syntax for a prompt-sequence.

Tracked internally by https://warthogs.atlassian.net/browse/UDENG-4782