### PR TITLE
fix(daemon): set TOKIO_WORKER_THREADS to stop tokio trying to read cgroup files which will result in apparmor denials

### DIFF
--- a/prompting-client/src/daemon/mod.rs
+++ b/prompting-client/src/daemon/mod.rs
@@ -7,7 +7,7 @@ use std::{env, fs, sync::Arc};
 use tokio::sync::mpsc::unbounded_channel;
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::{async_trait, transport::Server};
-use tracing::{error, info};
+use tracing::{debug, error};
 use tracing_subscriber::{reload::Handle, EnvFilter};
 
 mod poll;
@@ -76,14 +76,14 @@ where
         path,
     );
 
-    info!("spawning poll loop");
+    debug!("spawning poll loop");
     let poll_loop = PollLoop::new(c, tx_prompts);
     tokio::spawn(async move { poll_loop.run().await });
 
-    info!("spawning worker thread");
+    debug!("spawning worker thread");
     tokio::spawn(async move { worker.run().await });
 
-    info!("serving incoming grpc connections");
+    debug!("serving incoming grpc connections");
     let res = Server::builder()
         .add_service(server)
         .serve_with_incoming(UnixListenerStream::new(listener))

--- a/prompting-client/src/daemon/poll.rs
+++ b/prompting-client/src/daemon/poll.rs
@@ -65,7 +65,7 @@ impl PollLoop {
         let mut retries = 0;
 
         while self.running {
-            info!("polling for notices");
+            debug!("polling for notices");
             let notices = match self.client.pending_prompt_notices().await {
                 Ok(notices) => notices,
 

--- a/prompting-client/src/daemon/server.rs
+++ b/prompting-client/src/daemon/server.rs
@@ -25,7 +25,7 @@ use hyper::StatusCode;
 use std::sync::Arc;
 use tokio::{net::UnixListener, sync::mpsc::UnboundedSender};
 use tonic::{async_trait, Code, Request, Response, Status};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use tracing_subscriber::{reload::Handle, EnvFilter};
 
 macro_rules! map_enum {
@@ -143,7 +143,7 @@ where
         let prompt = match self.active_prompt.get() {
             Some(TypedUiInput::Home(input)) => {
                 let id = &input.id.0;
-                info!(%id, "serving request for active prompt (id={id})");
+                debug!(%id, "serving request for active prompt (id={id})");
                 Some(map_home_response(input))
             }
 
@@ -164,7 +164,7 @@ where
         let reply = map_prompt_reply(req.clone())?;
         let id = PromptId(req.prompt_id.clone());
 
-        info!(id=%id.0, "replying to prompt id={}", id.0);
+        debug!(id=%id.0, "replying to prompt id={}", id.0);
         let resp = match self.client.reply(&id, reply).await {
             Ok(others) => {
                 self.update_worker(ActionedPrompt::Actioned { id, others })

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,6 +16,7 @@ apps:
     extensions: [gnome]
     environment: &env
       PROMPTING_CLIENT_SOCKET: "${XDG_RUNTIME_DIR}/prompting.sock"
+      TOKIO_WORKER_THREADS: 2
     plugs: &plugs
       - home
       - snap-interfaces-requests-control


### PR DESCRIPTION
Addresses the issue reported in https://github.com/canonical/desktop-security-center/issues/71

@olivercalder confirms that this removes the log spam when running in a VM without a desktop session but he's still seeing the following denial which I'm yet to track down:
```
Oct 10 16:13:26 integration-oracular kernel: audit: type=1400 audit(1728576806.803:30728): apparmor="DENIED" operation="open" class="file" profile="snap-update-ns.prompting-client" name="/proc/417652/maps" pid=417652 comm="5" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
```

I've also reduced multiple log lines from `INFO` to `DEBUG` so the prompting client is less chatty by default.