### PR TITLE
feat(prompt_ui): add error message box

### DIFF
--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_error.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_error.dart
@@ -4,8 +4,7 @@ sealed class HomePromptError {
   const HomePromptError();
 
   String body(AppLocalizations l10n) => switch (this) {
-        HomePromptErrorUnknown(message: final message) =>
-          l10n.homePromptErrorUnknownBody(message),
+        HomePromptErrorUnknown(message: final message) => message
       };
   String title(AppLocalizations l10n) => switch (this) {
         HomePromptErrorUnknown() => l10n.homePromptErrorUnknownTitle,

--- a/flutter_packages/prompting_client_ui/lib/home/home_prompt_error.dart
+++ b/flutter_packages/prompting_client_ui/lib/home/home_prompt_error.dart
@@ -1,0 +1,18 @@
+import 'package:prompting_client_ui/l10n.dart';
+
+sealed class HomePromptError {
+  const HomePromptError();
+
+  String body(AppLocalizations l10n) => switch (this) {
+        HomePromptErrorUnknown(message: final message) =>
+          l10n.homePromptErrorUnknownBody(message),
+      };
+  String title(AppLocalizations l10n) => switch (this) {
+        HomePromptErrorUnknown() => l10n.homePromptErrorUnknownTitle,
+      };
+}
+
+class HomePromptErrorUnknown extends HomePromptError {
+  HomePromptErrorUnknown(this.message);
+  final String message;
+}

--- a/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
@@ -126,5 +126,15 @@
     "homePromptPermissionsWrite": "Write",
     "@homePromptPermissionsWrite": {},
     "homePromptPermissionsExecute": "Execute",
-    "@homePromptPermissionsExecute": {}
+    "@homePromptPermissionsExecute": {},
+    "homePromptErrorUnknownTitle": "Unknown error",
+    "@homePromptErrorUnknownTitle": {},
+    "homePromptErrorUnknownBody": "An unknown error occurred. Raw error message: {message}",
+    "@homePromptErrorUnknownBody": {
+        "placeholders": {
+            "message": {
+                "type": "String"
+            }
+        }
+    }
 }

--- a/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter_packages/prompting_client_ui/lib/l10n/app_en.arb
@@ -127,14 +127,6 @@
     "@homePromptPermissionsWrite": {},
     "homePromptPermissionsExecute": "Execute",
     "@homePromptPermissionsExecute": {},
-    "homePromptErrorUnknownTitle": "Unknown error",
-    "@homePromptErrorUnknownTitle": {},
-    "homePromptErrorUnknownBody": "An unknown error occurred. Raw error message: {message}",
-    "@homePromptErrorUnknownBody": {
-        "placeholders": {
-            "message": {
-                "type": "String"
-            }
-        }
-    }
+    "homePromptErrorUnknownTitle": "Something went wrong",
+    "@homePromptErrorUnknownTitle": {}
 }

--- a/flutter_packages/prompting_client_ui/lib/test_prompt_details.json
+++ b/flutter_packages/prompting_client_ui/lib/test_prompt_details.json
@@ -24,25 +24,25 @@
     "patternOptions": [
         {
             "homePatternType": "homeDirectory",
-            "pathPattern": "/home/user/**/*"
-        },
-        {
-            "homePatternType": "matchingFileExtension",
-            "pathPattern": "/home/user/**/*.jpeg"
+            "pathPattern": "/home/user/**"
         },
         {
             "homePatternType": "topLevelDirectory",
-            "pathPattern": "/home/user/Downloads/**/*",
+            "pathPattern": "/home/user/Downloads/**",
             "showInitially": true
         },
         {
-            "homePatternType": "requestedDirectory",
-            "pathPattern": "/home/user/Downloads/Minotaur/**/*",
+            "homePatternType": "containingDirectory",
+            "pathPattern": "/home/user/Downloads/Minotaur/**",
             "showInitially": true
         },
         {
             "homePatternType": "requestedFile",
             "pathPattern": "/home/user/Downloads/Minotaur/minotaur-13293232.jpeg"
+        },
+        {
+            "homePatternType": "matchingFileExtension",
+            "pathPattern": "/home/user/**/*.jpeg"
         }
     ],
     "initialPatternOption": 1

--- a/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter_packages/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/material.dart' hide Action, MetaData;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:prompting_client/prompting_client.dart';
+import 'package:prompting_client_ui/home/home_prompt_error.dart';
 import 'package:prompting_client_ui/l10n.dart';
 import 'package:prompting_client_ui/l10n_x.dart';
 import 'package:prompting_client_ui/prompt_page.dart';
@@ -453,7 +453,7 @@ void main() {
     }
   });
 
-  testWidgets('show custom path error', (tester) async {
+  testWidgets('show error message', (tester) async {
     final container = createContainer();
     registerMockPromptDetails(
       promptDetails: testDetails,
@@ -462,44 +462,8 @@ void main() {
       promptDetails: testDetails,
       replyResponse: PromptReplyResponse.unknown(message: 'error message'),
     );
-    await tester.pumpApp(
-      (_) => UncontrolledProviderScope(
-        container: container,
-        child: const PromptPage(),
-      ),
-    );
+    final expectedError = HomePromptErrorUnknown('error message');
 
-    await tester.tap(
-      find.text(tester.l10n.homePromptMoreOptionsLabel),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(
-      find.text(tester.l10n.homePatternTypeCustomPath),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.enterText(find.byType(TextFormField), 'invalid path');
-    await tester.tap(find.text(tester.l10n.promptActionOptionAllow));
-    await tester.pumpAndSettle();
-
-    expect(find.text('error message'), findsOneWidget);
-
-    await tester.enterText(find.byType(TextFormField), 'another path');
-    await tester.pumpAndSettle();
-
-    expect(find.text('error message'), findsNothing);
-  });
-
-  testWidgets('reveal custom path text field on error', (tester) async {
-    final container = createContainer();
-    registerMockPromptDetails(
-      promptDetails: testDetails,
-    );
-    registerMockAppArmorPromptingClient(
-      promptDetails: testDetails,
-      replyResponse: PromptReplyResponse.unknown(message: 'error message'),
-    );
     await tester.pumpApp(
       (_) => UncontrolledProviderScope(
         container: container,
@@ -510,6 +474,15 @@ void main() {
     await tester.tap(find.text(tester.l10n.promptActionOptionAllowAlways));
     await tester.pumpAndSettle();
 
-    expect(find.text('error message'), findsOneWidget);
+    expect(find.text(expectedError.body(tester.l10n)), findsOneWidget);
+    expect(find.text(expectedError.title(tester.l10n)), findsOneWidget);
+
+    await tester.tap(
+      find.text(tester.l10n.homePromptMoreOptionsLabel),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(expectedError.body(tester.l10n)), findsOneWidget);
+    expect(find.text(expectedError.title(tester.l10n)), findsOneWidget);
   });
 }


### PR DESCRIPTION
Adds an error box to the prompting UI to display generic errors received from the rust client when submitting a reply.

The only error we currently handle explicitly is `PROMPT_NOT_FOUND`, in which case UI closes normally when the reply is submitted, without any indication to the user that the prompt has already been handled and their reply is ignored (we have this as an issue in our backlog to come back to).

For `UNKNOWN` errors, all we can currently do is show a generic message along with the raw error string, see screen recording. We've previously shown the raw error message only as part of the text field validation for the custom path pattern. Generally, we don't know whether the error is related to the custom path pattern, so in this generic case we should completely disentangle the error message box and the field validation. Once there is a defined set of possible errors, we can show the text field error in addition to the message for errors that are related to the custom path submitted by the user.

[Screencast from 2024-10-16 11-51-14.webm](https://github.com/user-attachments/assets/ce5044ce-df45-4d3a-8417-a306da3cab1f)

@juanruitina do we want the error message to disappear again, once the user changes their selection in the UI?

UDENG-4963