### PR TITLE
feat: initial parsing of structured errors

### DIFF
--- a/prompting-client/resources/response-parsing-tests/empty-permissions-field.json
+++ b/prompting-client/resources/response-parsing-tests/empty-permissions-field.json
@@ -1,0 +1,19 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-invalid-fields",
+    "value": {
+      "permissions": {
+        "reason": "unsupported-value",
+        "supported": [
+          "bar",
+          "baz"
+        ],
+        "value": []
+      }
+    }
+  },
+  "status": "Bad Request",
+  "status-code": 400,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/internal-server-error.json
+++ b/prompting-client/resources/response-parsing-tests/internal-server-error.json
@@ -1,0 +1,8 @@
+{
+  "result": {
+    "message": "some error message"
+  },
+  "status": "Internal Server Error",
+  "status-code": 500,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/invalid-duration.json
+++ b/prompting-client/resources/response-parsing-tests/invalid-duration.json
@@ -1,0 +1,15 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-invalid-fields",
+    "value": {
+      "duration": {
+        "reason": "parse-error",
+        "value": "foo"
+      }
+    }
+  },
+  "status": "Bad Request",
+  "status-code": 400,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/invalid-expiration.json
+++ b/prompting-client/resources/response-parsing-tests/invalid-expiration.json
@@ -1,0 +1,15 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-invalid-fields",
+    "value": {
+      "expiration": {
+        "reason": "parse-error",
+        "value": "0001-02-03T04:05:06.000000007Z"
+      }
+    }
+  },
+  "status": "Bad Request",
+  "status-code": 400,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/invalid-interface-field.json
+++ b/prompting-client/resources/response-parsing-tests/invalid-interface-field.json
@@ -1,0 +1,21 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-invalid-fields",
+    "value": {
+      "interface": {
+        "reason": "unsupported-value",
+        "supported": [
+          "bar",
+          "baz"
+        ],
+        "value": [
+          "foo"
+        ]
+      }
+    }
+  },
+  "status": "Bad Request",
+  "status-code": 400,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/invalid-lifespan-field.json
+++ b/prompting-client/resources/response-parsing-tests/invalid-lifespan-field.json
@@ -1,0 +1,21 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-invalid-fields",
+    "value": {
+      "lifespan": {
+        "reason": "unsupported-value",
+        "supported": [
+          "bar",
+          "baz"
+        ],
+        "value": [
+          "foo"
+        ]
+      }
+    }
+  },
+  "status": "Bad Request",
+  "status-code": 400,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/invalid-path-pattern.json
+++ b/prompting-client/resources/response-parsing-tests/invalid-path-pattern.json
@@ -1,0 +1,15 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-reply-not-match-request",
+    "value": {
+      "path-pattern": {
+        "requested-path": "foo",
+        "replied-pattern": "bar"
+      }
+    }
+  },
+  "status": "Bad Request",
+  "status-code": 400,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/invalid-permissions.json
+++ b/prompting-client/resources/response-parsing-tests/invalid-permissions.json
@@ -1,0 +1,22 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-reply-not-match-request",
+    "value": {
+      "permissions": {
+        "requested-permissions": [
+          "foo",
+          "bar",
+          "baz"
+        ],
+        "replied-permissions": [
+          "fizz",
+          "buzz"
+        ]
+      }
+    }
+  },
+  "status": "Bad Request",
+  "status-code": 400,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/malformed-path-pattern.json
+++ b/prompting-client/resources/response-parsing-tests/malformed-path-pattern.json
@@ -1,0 +1,15 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-invalid-fields",
+    "value": {
+      "path-pattern": {
+        "reason": "parse-error",
+        "value": "invalid/pattern"
+      }
+    }
+  },
+  "status": "Bad Request",
+  "status-code": 400,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/malformed-permissions-field.json
+++ b/prompting-client/resources/response-parsing-tests/malformed-permissions-field.json
@@ -1,0 +1,22 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-invalid-fields",
+    "value": {
+      "permissions": {
+        "reason": "unsupported-value",
+        "supported": [
+          "fizz",
+          "buzz"
+        ],
+        "value": [
+          "bar",
+          "baz"
+        ]
+      }
+    }
+  },
+  "status": "Bad Request",
+  "status-code": 400,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/prompt-not-found.json
+++ b/prompting-client/resources/response-parsing-tests/prompt-not-found.json
@@ -1,0 +1,9 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-prompt-not-found"
+  },
+  "status": "Not Found",
+  "status-code": 404,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/rule-conflict.json
+++ b/prompting-client/resources/response-parsing-tests/rule-conflict.json
@@ -1,0 +1,23 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-rule-conflict",
+    "value": {
+      "conflicts": [
+        {
+          "permission": "foo",
+          "variant": "variant 1",
+          "conflicting-id": "conflicting rule 1"
+        },
+        {
+          "permission": "bar",
+          "variant": "variant 2",
+          "conflicting-id": "conflicting rule 2"
+        }
+      ]
+    }
+  },
+  "status": "Conflict",
+  "status-code": 409,
+  "type": "error"
+}

--- a/prompting-client/resources/response-parsing-tests/rule-not-found.json
+++ b/prompting-client/resources/response-parsing-tests/rule-not-found.json
@@ -1,0 +1,9 @@
+{
+  "result": {
+    "message": "some error message",
+    "kind": "interfaces-requests-rule-not-found"
+  },
+  "status": "Not Found",
+  "status-code": 404,
+  "type": "error"
+}

--- a/prompting-client/src/lib.rs
+++ b/prompting-client/src/lib.rs
@@ -22,6 +22,8 @@ mod recording;
 mod socket_client;
 mod util;
 
+use snapd_client::SnapdError;
+
 pub(crate) const SNAP_NAME: &str = "prompting-client";
 pub const SOCKET_ENV_VAR: &str = "PROMPTING_CLIENT_SOCKET";
 pub const DEFAULT_LOG_LEVEL: &str = "info";
@@ -78,7 +80,11 @@ pub enum Error {
     NotSupported { reason: String },
 
     #[error("error message returned from snapd: {message}")]
-    SnapdError { status: StatusCode, message: String },
+    SnapdError {
+        status: StatusCode,
+        message: String,
+        err: Box<SnapdError>,
+    },
 
     #[error("{interface} is not currently supported for apparmor prompting")]
     UnsupportedInterface { interface: String },

--- a/prompting-client/src/snapd_client/response.rs
+++ b/prompting-client/src/snapd_client/response.rs
@@ -1,0 +1,378 @@
+//! Parsing of snapd API responses
+use crate::{socket_client::body_json, Error, Result};
+use hyper::{body::Incoming, Response};
+use serde::{
+    de::{self, DeserializeOwned, Deserializer},
+    Deserialize, Serialize,
+};
+use serde_json::Value;
+use tracing::error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub enum SnapdError {
+    Raw,
+    PromptNotFound,
+    RuleNotFound,
+    RuleConflict {
+        conflicts: Vec<RuleConflict>,
+    },
+    InvalidReplyPermissions {
+        requested: Vec<String>,
+        replied: Vec<String>,
+    },
+    InvalidPathPattern {
+        requested: String,
+        replied: String,
+    },
+    MalformedFieldScalar {
+        reason: String,
+        field: &'static str,
+        value: String,
+    },
+    MalformedFieldVector {
+        reason: String,
+        field: &'static str,
+        value: Vec<String>,
+        supported: Vec<String>,
+    },
+    UnsupportedValue {
+        field: String,
+        supported: Vec<String>,
+        provided: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RuleConflict {
+    permission: String,
+    variant: String,
+    conflicting_id: String,
+}
+
+/// Parse a raw response body from snapd into our internal Result type
+pub async fn parse_response<T>(res: Response<Incoming>) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let status = res.status();
+    let resp: SnapdResponse<T> = body_json(res).await?;
+
+    resp.result.map_err(|(message, err)| Error::SnapdError {
+        status,
+        message,
+        err: Box::new(err),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct SnapdResponse<T> {
+    #[serde(rename = "type")]
+    ty: String,
+    status_code: u16,
+    status: String,
+    result: std::result::Result<T, (String, SnapdError)>,
+}
+
+impl<'de, T> Deserialize<'de> for SnapdResponse<T>
+where
+    T: DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Debug, Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        struct RawResponse {
+            #[serde(rename = "type")]
+            ty: String,
+            status_code: u16,
+            status: String,
+            result: serde_json::Value,
+        }
+
+        let RawResponse {
+            ty,
+            status_code,
+            status,
+            result,
+        } = RawResponse::deserialize(deserializer)?;
+
+        if ty != "error" {
+            let result = T::deserialize(result).map_err(de::Error::custom)?;
+            return Ok(SnapdResponse {
+                ty,
+                status_code,
+                status,
+                result: Ok(result),
+            });
+        }
+
+        #[derive(Debug, Deserialize)]
+        enum ErrorKind {
+            #[serde(rename = "interfaces-requests-invalid-fields")]
+            InvalidFields,
+            #[serde(rename = "interfaces-requests-prompt-not-found")]
+            PromptNotFound,
+            #[serde(rename = "interfaces-requests-reply-not-match-request")]
+            ReplyNotMatchRequest,
+            #[serde(rename = "interfaces-requests-rule-conflict")]
+            RuleConflict,
+            #[serde(rename = "interfaces-requests-rule-not-found")]
+            RuleNotFound,
+        }
+
+        #[derive(Debug, Deserialize)]
+        struct RawError {
+            message: String,
+            kind: Option<ErrorKind>,
+            value: Option<serde_json::Value>,
+        }
+
+        let RawError {
+            message,
+            kind,
+            value,
+        } = RawError::deserialize(result).map_err(de::Error::custom)?;
+
+        match (kind, value) {
+            (Some(ErrorKind::PromptNotFound), None) => Ok(SnapdResponse {
+                ty,
+                status_code,
+                status,
+                result: Err((message, SnapdError::PromptNotFound)),
+            }),
+
+            (Some(ErrorKind::RuleNotFound), None) => Ok(SnapdResponse {
+                ty,
+                status_code,
+                status,
+                result: Err((message, SnapdError::RuleNotFound)),
+            }),
+
+            (Some(ErrorKind::InvalidFields), Some(value)) => {
+                #[derive(Debug, Deserialize)]
+                #[serde(rename_all = "kebab-case")]
+                struct Fields {
+                    expiration: Option<StrValue>,
+                    duration: Option<StrValue>,
+                    path_pattern: Option<StrValue>,
+                    permissions: Option<VecSupportedValue>,
+                    interface: Option<VecSupportedValue>,
+                    lifespan: Option<VecSupportedValue>,
+                }
+
+                #[derive(Debug, Deserialize)]
+                struct StrValue {
+                    reason: String,
+                    value: String,
+                }
+
+                #[derive(Debug, Deserialize)]
+                struct VecSupportedValue {
+                    reason: String,
+                    supported: Vec<String>,
+                    value: Vec<String>,
+                }
+
+                let fs: Fields = serde_json::from_value(value).map_err(de::Error::custom)?;
+                let err = if let Some(e) = fs.path_pattern {
+                    SnapdError::MalformedFieldScalar {
+                        reason: e.reason,
+                        field: "path-pattern",
+                        value: e.value,
+                    }
+                } else if let Some(e) = fs.expiration {
+                    SnapdError::MalformedFieldScalar {
+                        reason: e.reason,
+                        field: "expiration",
+                        value: e.value,
+                    }
+                } else if let Some(e) = fs.duration {
+                    SnapdError::MalformedFieldScalar {
+                        reason: e.reason,
+                        field: "duration",
+                        value: e.value,
+                    }
+                } else if let Some(e) = fs.permissions {
+                    SnapdError::MalformedFieldVector {
+                        reason: e.reason,
+                        field: "permissions",
+                        value: e.value,
+                        supported: e.supported,
+                    }
+                } else if let Some(e) = fs.interface {
+                    SnapdError::MalformedFieldVector {
+                        reason: e.reason,
+                        field: "interface",
+                        value: e.value,
+                        supported: e.supported,
+                    }
+                } else if let Some(e) = fs.lifespan {
+                    SnapdError::MalformedFieldVector {
+                        reason: e.reason,
+                        field: "lifespan",
+                        value: e.value,
+                        supported: e.supported,
+                    }
+                } else {
+                    error!("malformed reply-not-match-request error from snapd");
+                    SnapdError::Raw
+                };
+
+                Ok(SnapdResponse {
+                    ty,
+                    status_code,
+                    status,
+                    result: Err((message, err)),
+                })
+            }
+
+            (Some(ErrorKind::ReplyNotMatchRequest), Some(value)) => {
+                #[derive(Debug, Deserialize)]
+                #[serde(rename_all = "kebab-case")]
+                struct Fields {
+                    path_pattern: Option<PathPatternError>,
+                    permissions: Option<PermissionsError>,
+                }
+
+                #[derive(Debug, Deserialize)]
+                #[serde(rename_all = "kebab-case")]
+                struct PathPatternError {
+                    requested_path: String,
+                    replied_pattern: String,
+                }
+
+                #[derive(Debug, Deserialize)]
+                #[serde(rename_all = "kebab-case")]
+                struct PermissionsError {
+                    requested_permissions: Vec<String>,
+                    replied_permissions: Vec<String>,
+                }
+
+                let fs: Fields = serde_json::from_value(value).map_err(de::Error::custom)?;
+                let err = match (fs.path_pattern, fs.permissions) {
+                    (Some(e), None) => SnapdError::InvalidPathPattern {
+                        requested: e.requested_path,
+                        replied: e.replied_pattern,
+                    },
+
+                    (None, Some(e)) => SnapdError::InvalidReplyPermissions {
+                        requested: e.requested_permissions,
+                        replied: e.replied_permissions,
+                    },
+
+                    _ => {
+                        error!("malformed reply-not-match-request error from snapd");
+                        SnapdError::Raw
+                    }
+                };
+
+                Ok(SnapdResponse {
+                    ty,
+                    status_code,
+                    status,
+                    result: Err((message, err)),
+                })
+            }
+
+            (Some(ErrorKind::RuleConflict), Some(mut value)) => {
+                let conflicts: Vec<RuleConflict> = match value["conflicts"].take() {
+                    Value::Null => {
+                        error!("malformed rule conflict error from snapd: {value}");
+                        return Ok(SnapdResponse {
+                            ty,
+                            status_code,
+                            status,
+                            result: Err((message, SnapdError::Raw)),
+                        });
+                    }
+
+                    val => serde_json::from_value(val).map_err(de::Error::custom)?,
+                };
+
+                Ok(SnapdResponse {
+                    ty,
+                    status_code,
+                    status,
+                    result: Err((message, SnapdError::RuleConflict { conflicts })),
+                })
+            }
+
+            (None, _) | (_, None) => Ok(SnapdResponse {
+                ty,
+                status_code,
+                status,
+                result: Err((message, SnapdError::Raw)),
+            }),
+
+            (kind, value) => {
+                error!("malformed error response from snapd: {kind:?} {value:?}");
+                Ok(SnapdResponse {
+                    ty,
+                    status_code,
+                    status,
+                    result: Err((message, SnapdError::Raw)),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::snapd_client::{PromptId, RawPrompt};
+    use simple_test_case::dir_cases;
+
+    #[dir_cases("resources/response-parsing-tests")]
+    #[test]
+    fn response_parsing_sanity_check(_path: &str, contents: &str) {
+        let _parsed: SnapdResponse<String> = serde_json::from_str(contents).unwrap();
+    }
+
+    const RAW_PROMPT: &str = r#"{
+  "result": {
+    "constraints": {
+      "available-permissions": [
+        "read",
+        "write",
+        "execute"
+      ],
+      "path": "/home/ubuntu/test/0ec9a598-eee3-4785-bd5a-c5c0e3ff04e9/test-2.txt",
+      "requested-permissions": [
+        "write"
+      ]
+    },
+    "id": "00000000000000BE",
+    "interface": "home",
+    "snap": "aa-prompting-test",
+    "timestamp": "2024-08-15T13:28:17.077016791Z"
+  },
+  "status": "OK",
+  "status-code": 200,
+  "type": "sync",
+  "warning-count": 2,
+  "warning-timestamp": "2024-08-14T06:39:37.371971895Z"
+}"#;
+
+    #[test]
+    fn raw_prompt_parsing_works() {
+        let raw: SnapdResponse<RawPrompt> = serde_json::from_str(RAW_PROMPT).unwrap();
+        let expected = RawPrompt {
+            id: PromptId("00000000000000BE".to_string()),
+            timestamp: "2024-08-15T13:28:17.077016791Z".to_string(),
+            snap: "aa-prompting-test".to_string(),
+            interface: "home".to_string(),
+            constraints: serde_json::json!({
+                "available-permissions": vec!["read", "write", "execute"],
+                "path": "/home/ubuntu/test/0ec9a598-eee3-4785-bd5a-c5c0e3ff04e9/test-2.txt",
+                "requested-permissions": vec!["write"]
+            }),
+        };
+
+        assert_eq!(raw.result, Ok(expected));
+    }
+}


### PR DESCRIPTION
Currently WIP. This gets us parsing of the snapd error responses found in the `resources` directory but we still need to update the proto to support passing the structured data to the UI.