### PR TITLE
feat: path based prompting message

### DIFF
--- a/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
@@ -89,7 +89,7 @@
             }
         }
     },
-    "homePromptSubfolderBody": "{snap} wants to get {permissions} access to {path}",
+    "homePromptSubFolderBody": "{snap} wants to get {permissions} access to {path}",
     "@homePromptSubfolderBody": {
         "placeholders": {
             "snap": {

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
@@ -89,7 +89,7 @@
             }
         }
     },
-    "homePromptTopLevelDirBody": "{snap} wants to get {permissions} access to the {foldername} folder",
+    "homePromptTopLevelDirBody": "{snap} wants to get {permissions} access to the {foldername} folder.",
     "@homePromptTopLevelDirBody": {
         "placeholders": {
             "snap": {
@@ -103,7 +103,7 @@
             }
         }
     },
-    "homePromptTopLevelDirBody": "{snap} wants to get {permissions} access to the {foldername} folder",
+    "homePromptTopLevelDirBody": "{snap} wants to get {permissions} access to the {foldername} folder.",
     "@homePromptTopLevelDirBody": {
         "placeholders": {
             "snap": {
@@ -117,7 +117,7 @@
             }
         }
     },
-    "homePromptTopLevelDirFileBody": "{snap} wants to get {permissions} access to {filename} in the {foldername} folder",
+    "homePromptTopLevelDirFileBody": "{snap} wants to get {permissions} access to {filename} in the {foldername} folder.",
     "@homePromptTopLevelDirFileBody": {
         "placeholders": {
             "snap": {
@@ -134,7 +134,7 @@
             }
         }
     },
-    "homePromptHomeDirBody": "{snap} wants to get {permissions} access to your Home folder",
+    "homePromptHomeDirBody": "{snap} wants to get {permissions} access to your Home folder.",
     "@homePromptHomeDirBody": {
         "placeholders": {
             "snap": {
@@ -145,7 +145,7 @@
             }
         }
     },
-    "homePromptHomeDirFileBody": "{snap} wants to get {permissions} access to {filename} in your Home folder",
+    "homePromptHomeDirFileBody": "{snap} wants to get {permissions} access to {filename} in your Home folder.",
     "@homePromptHomeDirFileBody": {
         "placeholders": {
             "snap": {

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
@@ -75,8 +75,8 @@
             }
         }
     },
-    "homePromptBody": "{snap} wants to get {permissions} access to {path} in your home folder",
-    "@homePromptBody": {
+    "homePromptDefaultBody": "{snap} wants to get {permissions} access to {path}",
+    "@homePromptDefaultBody": {
         "placeholders": {
             "snap": {
                 "type": "String"
@@ -89,8 +89,8 @@
             }
         }
     },
-    "homePromptSubFolderBody": "{snap} wants to get {permissions} access to {path}",
-    "@homePromptSubfolderBody": {
+    "homePromptHomeDirectoryBody": "{snap} wants to get {permissions} access to {path} in your home folder",
+    "@homePromptHomeDirectoryBody": {
         "placeholders": {
             "snap": {
                 "type": "String"

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
@@ -145,7 +145,7 @@
             }
         }
     },
-    "homePromptHomeDirFileBody": "{snap} wants to get {permissions} access to file {filename} in your Home folder",
+    "homePromptHomeDirFileBody": "{snap} wants to get {permissions} access to {filename} in your Home folder",
     "@homePromptHomeDirFileBody": {
         "placeholders": {
             "snap": {

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
@@ -89,8 +89,8 @@
             }
         }
     },
-    "homePromptHomeDirectoryBody": "{snap} wants to get {permissions} access to {path} in your home folder",
-    "@homePromptHomeDirectoryBody": {
+    "homePromptTopLevelDirBody": "{snap} wants to get {permissions} access to the {foldername} folder",
+    "@homePromptTopLevelDirBody": {
         "placeholders": {
             "snap": {
                 "type": "String"
@@ -98,13 +98,27 @@
             "permissions": {
                 "type": "String"
             },
-            "path": {
+            "folder": {
                 "type": "String"
             }
         }
     },
-    "homePromptTopLevelFolderBody": "{snap} wants to get {permissions} access to {filename} in the {foldername} folder",
-    "@homePromptTopLevelFolderBody": {
+    "homePromptTopLevelDirBody": "{snap} wants to get {permissions} access to the {foldername} folder",
+    "@homePromptTopLevelDirBody": {
+        "placeholders": {
+            "snap": {
+                "type": "String"
+            },
+            "permissions": {
+                "type": "String"
+            },
+            "foldername": {
+                "type": "String"
+            }
+        }
+    },
+    "homePromptTopLevelDirFileBody": "{snap} wants to get {permissions} access to {filename} in the {foldername} folder",
+    "@homePromptTopLevelDirFileBody": {
         "placeholders": {
             "snap": {
                 "type": "String"
@@ -116,6 +130,31 @@
                 "type": "String"
             },
             "foldername": {
+                "type": "String"
+            }
+        }
+    },
+    "homePromptHomeDirBody": "{snap} wants to get {permissions} access to your Home folder",
+    "@homePromptHomeDirBody": {
+        "placeholders": {
+            "snap": {
+                "type": "String"
+            },
+            "permissions": {
+                "type": "String"
+            }
+        }
+    },
+    "homePromptHomeDirFileBody": "{snap} wants to get {permissions} access to file {filename} in your Home folder",
+    "@homePromptHomeDirFileBody": {
+        "placeholders": {
+            "snap": {
+                "type": "String"
+            },
+            "permissions": {
+                "type": "String"
+            },
+            "filename": {
                 "type": "String"
             }
         }

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
@@ -75,7 +75,7 @@
             }
         }
     },
-    "homePromptBody": "Allow {snap} to have {permissions} access to {path}?",
+    "homePromptBody": "{snap} wants to get {permissions} access to {path} in your home folder",
     "@homePromptBody": {
         "placeholders": {
             "snap": {
@@ -85,6 +85,37 @@
                 "type": "String"
             },
             "path": {
+                "type": "String"
+            }
+        }
+    },
+    "homePromptSubfolderBody": "{snap} wants to get {permissions} access to {path}",
+    "@homePromptSubfolderBody": {
+        "placeholders": {
+            "snap": {
+                "type": "String"
+            },
+            "permissions": {
+                "type": "String"
+            },
+            "path": {
+                "type": "String"
+            }
+        }
+    },
+    "homePromptTopLevelFolderBody": "{snap} wants to get {permissions} access to {filename} in the {foldername} folder",
+    "@homePromptTopLevelFolderBody": {
+        "placeholders": {
+            "snap": {
+                "type": "String"
+            },
+            "permissions": {
+                "type": "String"
+            },
+            "filename": {
+                "type": "String"
+            },
+            "foldername": {
                 "type": "String"
             }
         }

--- a/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_data_model.dart
+++ b/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_data_model.dart
@@ -15,6 +15,7 @@ class HomePromptData with _$HomePromptData {
     required Set<HomePermission> permissions,
     required String customPath,
     required PatternOption patternOption,
+    required EnrichedPathKind enrichedPathKind,
     @Default(Lifespan.forever) Lifespan lifespan,
     HomePromptError? error,
     @Default(false) bool showMoreOptions,
@@ -55,6 +56,7 @@ class HomePromptDataModel extends _$HomePromptDataModel {
               .clamp(0, details.patternOptions.length - 1)],
       permissions: details.requestedPermissions,
       customPath: details.requestedPath,
+      enrichedPathKind: details.enrichedPathKind,
     );
   }
 

--- a/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
+++ b/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
@@ -73,57 +73,62 @@ class Header extends ConsumerWidget {
     );
     final l10n = AppLocalizations.of(context);
 
-    final markdownText = enrichedPathKind.when(
-      homeDir: () => l10n.homePromptHomeDirBody(
-        details.metaData.snapName.bold(),
-        details.requestedPermissions
-            .map((p) => p.localize(l10n).toLowerCase())
-            .join(', ')
-            .bold(),
-      ),
-      topLevelDir: (dirname) => l10n.homePromptTopLevelDirBody(
-        details.metaData.snapName.bold(),
-        details.requestedPermissions
-            .map((p) => p.localize(l10n).toLowerCase())
-            .join(', ')
-            .bold(),
-        dirname.bold(),
-      ),
-      subDir: () => l10n.homePromptDefaultBody(
-        details.metaData.snapName.bold(),
-        details.requestedPermissions
-            .map((p) => p.localize(l10n).toLowerCase())
-            .join(', ')
-            .bold(),
-        details.requestedPath.bold(),
-      ),
-      homeDirFile: (filename) => l10n.homePromptHomeDirFileBody(
-        details.metaData.snapName.bold(),
-        details.requestedPermissions
-            .map((p) => p.localize(l10n).toLowerCase())
-            .join(', ')
-            .bold(),
-        filename.bold(),
-      ),
-      topLevelDirFile: (dirname, filename) =>
-          l10n.homePromptTopLevelDirFileBody(
-        details.metaData.snapName.bold(),
-        details.requestedPermissions
-            .map((p) => p.localize(l10n).toLowerCase())
-            .join(', ')
-            .bold(),
-        filename.bold(),
-        dirname.bold(),
-      ),
-      subDirFile: () => l10n.homePromptDefaultBody(
-        details.metaData.snapName.bold(),
-        details.requestedPermissions
-            .map((p) => p.localize(l10n).toLowerCase())
-            .join(', ')
-            .bold(),
-        details.requestedPath.bold(),
-      ),
-    );
+    final markdownText = switch (enrichedPathKind) {
+      EnrichedPathKindHomeDir() => l10n.homePromptHomeDirBody(
+          details.metaData.snapName.bold(),
+          details.requestedPermissions
+              .map((p) => p.localize(l10n).toLowerCase())
+              .join(', ')
+              .bold(),
+        ),
+      EnrichedPathKindTopLevelDir(dirname: final dirname) =>
+        l10n.homePromptTopLevelDirBody(
+          details.metaData.snapName.bold(),
+          details.requestedPermissions
+              .map((p) => p.localize(l10n).toLowerCase())
+              .join(', ')
+              .bold(),
+          dirname.bold(),
+        ),
+      EnrichedPathKindSubDir() => l10n.homePromptDefaultBody(
+          details.metaData.snapName.bold(),
+          details.requestedPermissions
+              .map((p) => p.localize(l10n).toLowerCase())
+              .join(', ')
+              .bold(),
+          details.requestedPath.bold(),
+        ),
+      EnrichedPathKindHomeDirFile(filename: final filename) =>
+        l10n.homePromptHomeDirFileBody(
+          details.metaData.snapName.bold(),
+          details.requestedPermissions
+              .map((p) => p.localize(l10n).toLowerCase())
+              .join(', ')
+              .bold(),
+          filename.bold(),
+        ),
+      EnrichedPathKindTopLevelDirFile(
+        dirname: final dirname,
+        filename: final filename
+      ) =>
+        l10n.homePromptTopLevelDirFileBody(
+          details.metaData.snapName.bold(),
+          details.requestedPermissions
+              .map((p) => p.localize(l10n).toLowerCase())
+              .join(', ')
+              .bold(),
+          filename.bold(),
+          dirname.bold(),
+        ),
+      EnrichedPathKindSubDirFile() => l10n.homePromptDefaultBody(
+          details.metaData.snapName.bold(),
+          details.requestedPermissions
+              .map((p) => p.localize(l10n).toLowerCase())
+              .join(', ')
+              .bold(),
+          details.requestedPath.bold(),
+        ),
+    };
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
+++ b/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
@@ -68,8 +68,10 @@ class Header extends ConsumerWidget {
     final hasMeta = ref.watch(
       homePromptDataModelProvider.select((m) => m.hasMeta),
     );
-    final patternType = ref.watch(homePromptDataModelProvider
-        .select((m) => m.patternOption.homePatternType));
+    final patternType = ref.watch(
+      homePromptDataModelProvider
+          .select((m) => m.patternOption.homePatternType),
+    );
     final l10n = AppLocalizations.of(context);
 
     String markdownText;

--- a/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
+++ b/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
@@ -77,18 +77,6 @@ class Header extends ConsumerWidget {
     String markdownText;
 
     switch (patternType) {
-      case HomePatternType.requestedDirectory:
-        markdownText = l10n.homePromptSubFolderBody(
-          details.metaData.snapName.bold(),
-          details.requestedPermissions
-              .map((p) => p.localize(l10n).toLowerCase())
-              .join(', ')
-              .bold(),
-          details.requestedPath.bold(),
-        );
-
-        break;
-
       case HomePatternType.topLevelDirectory:
         final lastSlash = details.requestedPath.lastIndexOf('/');
         markdownText = l10n.homePromptTopLevelFolderBody(
@@ -97,13 +85,24 @@ class Header extends ConsumerWidget {
               .map((p) => p.localize(l10n).toLowerCase())
               .join(', ')
               .bold(),
+          // Filename is after the last "/" in the file path
           details.requestedPath.substring(lastSlash + 1).bold(),
-          details.requestedPath.substring(0, lastSlash).bold(),
+          // Foldername is between the secondlast and last "/"
+          details.requestedPath.substring(lastSlash - 1, lastSlash).bold(),
         );
         break;
-
+      case HomePatternType.homeDirectory:
+        markdownText = l10n.homePromptHomeDirectoryBody(
+          details.metaData.snapName.bold(),
+          details.requestedPermissions
+              .map((p) => p.localize(l10n).toLowerCase())
+              .join(', ')
+              .bold(),
+          details.requestedPath.bold(),
+        );
+        break;
       default:
-        markdownText = l10n.homePromptBody(
+        markdownText = l10n.homePromptDefaultBody(
           details.metaData.snapName.bold(),
           details.requestedPermissions
               .map((p) => p.localize(l10n).toLowerCase())

--- a/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
+++ b/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
@@ -76,7 +76,7 @@ class Header extends ConsumerWidget {
 
     switch (patternType) {
       case HomePatternType.requestedDirectory:
-        markdownText = l10n.homePromptSubfolderBody(
+        markdownText = l10n.homePromptSubFolderBody(
           details.metaData.snapName.bold(),
           details.requestedPermissions
               .map((p) => p.localize(l10n).toLowerCase())

--- a/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
+++ b/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
@@ -68,20 +68,55 @@ class Header extends ConsumerWidget {
     final hasMeta = ref.watch(
       homePromptDataModelProvider.select((m) => m.hasMeta),
     );
+    final patternType = ref.watch(homePromptDataModelProvider
+        .select((m) => m.patternOption.homePatternType));
     final l10n = AppLocalizations.of(context);
+
+    String markdownText;
+
+    switch (patternType) {
+      case HomePatternType.requestedDirectory:
+        markdownText = l10n.homePromptSubfolderBody(
+          details.metaData.snapName.bold(),
+          details.requestedPermissions
+              .map((p) => p.localize(l10n).toLowerCase())
+              .join(', ')
+              .bold(),
+          details.requestedPath.bold(),
+        );
+
+        break;
+
+      case HomePatternType.topLevelDirectory:
+        final lastSlash = details.requestedPath.lastIndexOf('/');
+        markdownText = l10n.homePromptTopLevelFolderBody(
+          details.metaData.snapName.bold(),
+          details.requestedPermissions
+              .map((p) => p.localize(l10n).toLowerCase())
+              .join(', ')
+              .bold(),
+          details.requestedPath.substring(lastSlash + 1).bold(),
+          details.requestedPath.substring(0, lastSlash).bold(),
+        );
+        break;
+
+      default:
+        markdownText = l10n.homePromptBody(
+          details.metaData.snapName.bold(),
+          details.requestedPermissions
+              .map((p) => p.localize(l10n).toLowerCase())
+              .join(', ')
+              .bold(),
+          details.requestedPath.bold(),
+        );
+        break;
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         MarkdownText(
-          l10n.homePromptBody(
-            details.metaData.snapName.bold(),
-            details.requestedPermissions
-                .map((p) => p.localize(l10n).toLowerCase())
-                .join(', ')
-                .bold(),
-            details.requestedPath.bold(),
-          ),
+          markdownText,
         ),
         if (hasMeta) const MetaDataDropdown(),
       ],

--- a/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
+++ b/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
@@ -68,50 +68,62 @@ class Header extends ConsumerWidget {
     final hasMeta = ref.watch(
       homePromptDataModelProvider.select((m) => m.hasMeta),
     );
-    final patternType = ref.watch(
-      homePromptDataModelProvider
-          .select((m) => m.patternOption.homePatternType),
+    final enrichedPathKind = ref.watch(
+      homePromptDataModelProvider.select((m) => m.enrichedPathKind),
     );
     final l10n = AppLocalizations.of(context);
 
-    String markdownText;
-
-    switch (patternType) {
-      case HomePatternType.topLevelDirectory:
-        final lastSlash = details.requestedPath.lastIndexOf('/');
-        markdownText = l10n.homePromptTopLevelFolderBody(
-          details.metaData.snapName.bold(),
-          details.requestedPermissions
-              .map((p) => p.localize(l10n).toLowerCase())
-              .join(', ')
-              .bold(),
-          // Filename is after the last "/" in the file path
-          details.requestedPath.substring(lastSlash + 1).bold(),
-          // Foldername is between the secondlast and last "/"
-          details.requestedPath.substring(lastSlash - 1, lastSlash).bold(),
-        );
-        break;
-      case HomePatternType.homeDirectory:
-        markdownText = l10n.homePromptHomeDirectoryBody(
-          details.metaData.snapName.bold(),
-          details.requestedPermissions
-              .map((p) => p.localize(l10n).toLowerCase())
-              .join(', ')
-              .bold(),
-          details.requestedPath.bold(),
-        );
-        break;
-      default:
-        markdownText = l10n.homePromptDefaultBody(
-          details.metaData.snapName.bold(),
-          details.requestedPermissions
-              .map((p) => p.localize(l10n).toLowerCase())
-              .join(', ')
-              .bold(),
-          details.requestedPath.bold(),
-        );
-        break;
-    }
+    final markdownText = enrichedPathKind.when(
+      homeDir: () => l10n.homePromptHomeDirBody(
+        details.metaData.snapName.bold(),
+        details.requestedPermissions
+            .map((p) => p.localize(l10n).toLowerCase())
+            .join(', ')
+            .bold(),
+      ),
+      topLevelDir: (dirname) => l10n.homePromptTopLevelDirBody(
+        details.metaData.snapName.bold(),
+        details.requestedPermissions
+            .map((p) => p.localize(l10n).toLowerCase())
+            .join(', ')
+            .bold(),
+        dirname.bold(),
+      ),
+      subDir: () => l10n.homePromptDefaultBody(
+        details.metaData.snapName.bold(),
+        details.requestedPermissions
+            .map((p) => p.localize(l10n).toLowerCase())
+            .join(', ')
+            .bold(),
+        details.requestedPath.bold(),
+      ),
+      homeDirFile: (filename) => l10n.homePromptHomeDirFileBody(
+        details.metaData.snapName.bold(),
+        details.requestedPermissions
+            .map((p) => p.localize(l10n).toLowerCase())
+            .join(', ')
+            .bold(),
+        filename.bold(),
+      ),
+      topLevelDirFile: (dirname, filename) =>
+          l10n.homePromptTopLevelDirFileBody(
+        details.metaData.snapName.bold(),
+        details.requestedPermissions
+            .map((p) => p.localize(l10n).toLowerCase())
+            .join(', ')
+            .bold(),
+        filename.bold(),
+        dirname.bold(),
+      ),
+      subDirFile: () => l10n.homePromptDefaultBody(
+        details.metaData.snapName.bold(),
+        details.requestedPermissions
+            .map((p) => p.localize(l10n).toLowerCase())
+            .join(', ')
+            .bold(),
+        details.requestedPath.bold(),
+      ),
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/flutter/apps/prompting_client_ui/lib/test_prompt_details.json
+++ b/flutter/apps/prompting_client_ui/lib/test_prompt_details.json
@@ -45,5 +45,8 @@
             "pathPattern": "/home/user/**/*.jpeg"
         }
     ],
-    "initialPatternOption": 1
+    "initialPatternOption": 1,
+    "enrichedPathKind": {
+        "runtimeType": "subDirFile"
+    }
 }

--- a/flutter/apps/prompting_client_ui/pubspec.lock
+++ b/flutter/apps/prompting_client_ui/pubspec.lock
@@ -400,10 +400,10 @@ packages:
     dependency: transitive
     description:
       name: grpc
-      sha256: e93ee3bce45c134bf44e9728119102358c7cd69de7832d9a874e2e74eb8cab40
+      sha256: "5b99b7a420937d4361ece68b798c9af8e04b5bc128a7859f2a4be87427694813"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.4"
+    version: "4.0.1"
   gsettings:
     dependency: transitive
     description:

--- a/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -249,7 +249,7 @@ void main() {
 
         expect(
           find.text(
-            tester.l10n.homePromptBody(
+            tester.l10n.homePromptDefaultBody(
               'firefox',
               HomePermission.read.localize(tester.l10n).toLowerCase(),
               testCase.requestedPath,
@@ -307,7 +307,7 @@ void main() {
 
     expect(
       find.text(
-        tester.l10n.homePromptBody(
+        tester.l10n.homePromptDefaultBody(
           'firefox',
           HomePermission.read.localize(tester.l10n).toLowerCase(),
           '/home/ubuntu/Downloads/file.txt',

--- a/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -264,8 +264,8 @@ void main() {
           ),
         );
 
-        testCase.enrichedPathKind.when(
-          homeDir: () {
+        switch (testCase.enrichedPathKind) {
+          case EnrichedPathKindHomeDir():
             expect(
               find.text(
                 tester.l10n.homePromptHomeDirBody(
@@ -275,8 +275,9 @@ void main() {
               ),
               findsOneWidget,
             );
-          },
-          homeDirFile: (filename) {
+            break;
+
+          case EnrichedPathKindHomeDirFile(filename: final filename):
             expect(
               find.text(
                 tester.l10n.homePromptHomeDirFileBody(
@@ -287,8 +288,9 @@ void main() {
               ),
               findsOneWidget,
             );
-          },
-          topLevelDir: (dirname) {
+            break;
+
+          case EnrichedPathKindTopLevelDir(dirname: final dirname):
             expect(
               find.text(
                 tester.l10n.homePromptTopLevelDirBody(
@@ -299,8 +301,12 @@ void main() {
               ),
               findsOneWidget,
             );
-          },
-          topLevelDirFile: (dirname, filename) {
+            break;
+
+          case EnrichedPathKindTopLevelDirFile(
+              dirname: final dirname,
+              filename: final filename
+            ):
             expect(
               find.text(
                 tester.l10n.homePromptTopLevelDirFileBody(
@@ -312,8 +318,9 @@ void main() {
               ),
               findsOneWidget,
             );
-          },
-          subDir: () {
+            break;
+
+          case EnrichedPathKindSubDir():
             expect(
               find.text(
                 tester.l10n.homePromptDefaultBody(
@@ -324,8 +331,9 @@ void main() {
               ),
               findsOneWidget,
             );
-          },
-          subDirFile: () {
+            break;
+
+          case EnrichedPathKindSubDirFile():
             expect(
               find.text(
                 tester.l10n.homePromptDefaultBody(
@@ -336,8 +344,8 @@ void main() {
               ),
               findsOneWidget,
             );
-          },
-        );
+            break;
+        }
 
         expect(
           find.text(tester.l10n.homePromptMetaDataPublishedBy('Mozilla')),

--- a/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -369,17 +369,18 @@ void main() {
   testWidgets('display prompt details without meta', (tester) async {
     final container = createContainer();
     final testDetailsWithoutMeta = testDetails.copyWith(
-      metaData: MetaData(
-        promptId: 'promptId',
-        snapName: 'firefox',
-        publisher: '',
-        storeUrl: '',
-      ),
-      enrichedPathKind: EnrichedPathKind.topLevelDirFile(dirname: 'Downloads', filename: 'file.txt')
-    );
+        metaData: MetaData(
+          promptId: 'promptId',
+          snapName: 'firefox',
+          publisher: '',
+          storeUrl: '',
+        ),
+        enrichedPathKind: EnrichedPathKind.topLevelDirFile(
+          dirname: 'Downloads',
+          filename: 'file.txt',
+        ),);
     registerMockPromptDetails(
       promptDetails: testDetailsWithoutMeta,
-
     );
     await tester.pumpApp(
       (_) => UncontrolledProviderScope(

--- a/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -369,16 +369,17 @@ void main() {
   testWidgets('display prompt details without meta', (tester) async {
     final container = createContainer();
     final testDetailsWithoutMeta = testDetails.copyWith(
-        metaData: MetaData(
-          promptId: 'promptId',
-          snapName: 'firefox',
-          publisher: '',
-          storeUrl: '',
-        ),
-        enrichedPathKind: EnrichedPathKind.topLevelDirFile(
-          dirname: 'Downloads',
-          filename: 'file.txt',
-        ),);
+      metaData: MetaData(
+        promptId: 'promptId',
+        snapName: 'firefox',
+        publisher: '',
+        storeUrl: '',
+      ),
+      enrichedPathKind: EnrichedPathKind.topLevelDirFile(
+        dirname: 'Downloads',
+        filename: 'file.txt',
+      ),
+    );
     registerMockPromptDetails(
       promptDetails: testDetailsWithoutMeta,
     );

--- a/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -41,10 +41,12 @@ void main() {
       String name,
       String requestedPath,
       Set<PatternOption> options,
+      EnrichedPathKind enrichedPathKind,
     })>[
       (
         name: 'file in subfolder',
         requestedPath: '/home/user/Pictures/nested/foo.jpeg',
+        enrichedPathKind: EnrichedPathKind.subDirFile(),
         options: {
           PatternOption(
             homePatternType: HomePatternType.homeDirectory,
@@ -73,6 +75,7 @@ void main() {
       (
         name: 'file in subfolder without extension',
         requestedPath: '/home/user/Pictures/nested/foo',
+        enrichedPathKind: EnrichedPathKind.subDirFile(),
         options: {
           PatternOption(
             homePatternType: HomePatternType.homeDirectory,
@@ -97,6 +100,10 @@ void main() {
       (
         name: 'file in top level folder',
         requestedPath: '/home/user/Downloads/foo.jpeg',
+        enrichedPathKind: EnrichedPathKind.topLevelDirFile(
+          filename: 'foo.jpeg',
+          dirname: 'Downloads',
+        ),
         options: {
           PatternOption(
             homePatternType: HomePatternType.homeDirectory,
@@ -121,6 +128,10 @@ void main() {
       (
         name: 'file in top level folder without extension',
         requestedPath: '/home/user/Downloads/foo',
+        enrichedPathKind: EnrichedPathKind.topLevelDirFile(
+          filename: 'foo',
+          dirname: 'Downloads',
+        ),
         options: {
           PatternOption(
             homePatternType: HomePatternType.homeDirectory,
@@ -141,6 +152,7 @@ void main() {
       (
         name: 'file in home folder',
         requestedPath: '/home/user/foo.jpeg',
+        enrichedPathKind: EnrichedPathKind.homeDirFile(filename: 'foo.jpeg'),
         options: {
           PatternOption(
             homePatternType: HomePatternType.homeDirectory,
@@ -160,6 +172,7 @@ void main() {
       (
         name: 'file in home folder without extension',
         requestedPath: '/home/user/foo',
+        enrichedPathKind: EnrichedPathKind.homeDirFile(filename: 'foo'),
         options: {
           PatternOption(
             homePatternType: HomePatternType.homeDirectory,
@@ -175,6 +188,7 @@ void main() {
       (
         name: 'sub folder',
         requestedPath: '/home/user/Downloads/stuff/',
+        enrichedPathKind: EnrichedPathKind.subDir(),
         options: {
           PatternOption(
             homePatternType: HomePatternType.homeDirectory,
@@ -200,6 +214,7 @@ void main() {
       (
         name: 'top level folder',
         requestedPath: '/home/user/Downloads/',
+        enrichedPathKind: EnrichedPathKind.topLevelDir(dirname: 'Downloads'),
         options: {
           PatternOption(
             homePatternType: HomePatternType.homeDirectory,
@@ -220,6 +235,7 @@ void main() {
       (
         name: 'top level folder',
         requestedPath: '/home/user/',
+        enrichedPathKind: EnrichedPathKind.homeDir(),
         options: {
           PatternOption(
             homePatternType: HomePatternType.homeDirectory,
@@ -238,6 +254,7 @@ void main() {
           promptDetails: testDetails.copyWith(
             requestedPath: testCase.requestedPath,
             patternOptions: testCase.options,
+            enrichedPathKind: testCase.enrichedPathKind,
           ),
         );
         await tester.pumpApp(
@@ -247,15 +264,79 @@ void main() {
           ),
         );
 
-        expect(
-          find.text(
-            tester.l10n.homePromptDefaultBody(
-              'firefox',
-              HomePermission.read.localize(tester.l10n).toLowerCase(),
-              testCase.requestedPath,
-            ),
-          ),
-          findsOneWidget,
+        testCase.enrichedPathKind.when(
+          homeDir: () {
+            expect(
+              find.text(
+                tester.l10n.homePromptHomeDirBody(
+                  'firefox',
+                  HomePermission.read.localize(tester.l10n).toLowerCase(),
+                ),
+              ),
+              findsOneWidget,
+            );
+          },
+          homeDirFile: (filename) {
+            expect(
+              find.text(
+                tester.l10n.homePromptHomeDirFileBody(
+                  'firefox',
+                  HomePermission.read.localize(tester.l10n).toLowerCase(),
+                  filename,
+                ),
+              ),
+              findsOneWidget,
+            );
+          },
+          topLevelDir: (dirname) {
+            expect(
+              find.text(
+                tester.l10n.homePromptTopLevelDirBody(
+                  'firefox',
+                  HomePermission.read.localize(tester.l10n).toLowerCase(),
+                  dirname,
+                ),
+              ),
+              findsOneWidget,
+            );
+          },
+          topLevelDirFile: (dirname, filename) {
+            expect(
+              find.text(
+                tester.l10n.homePromptTopLevelDirFileBody(
+                  'firefox',
+                  HomePermission.read.localize(tester.l10n).toLowerCase(),
+                  filename,
+                  dirname,
+                ),
+              ),
+              findsOneWidget,
+            );
+          },
+          subDir: () {
+            expect(
+              find.text(
+                tester.l10n.homePromptDefaultBody(
+                  'firefox',
+                  HomePermission.read.localize(tester.l10n).toLowerCase(),
+                  testCase.requestedPath,
+                ),
+              ),
+              findsOneWidget,
+            );
+          },
+          subDirFile: () {
+            expect(
+              find.text(
+                tester.l10n.homePromptDefaultBody(
+                  'firefox',
+                  HomePermission.read.localize(tester.l10n).toLowerCase(),
+                  testCase.requestedPath,
+                ),
+              ),
+              findsOneWidget,
+            );
+          },
         );
 
         expect(
@@ -294,9 +375,11 @@ void main() {
         publisher: '',
         storeUrl: '',
       ),
+      enrichedPathKind: EnrichedPathKind.topLevelDirFile(dirname: 'Downloads', filename: 'file.txt')
     );
     registerMockPromptDetails(
       promptDetails: testDetailsWithoutMeta,
+
     );
     await tester.pumpApp(
       (_) => UncontrolledProviderScope(
@@ -307,10 +390,11 @@ void main() {
 
     expect(
       find.text(
-        tester.l10n.homePromptDefaultBody(
+        tester.l10n.homePromptTopLevelDirFileBody(
           'firefox',
           HomePermission.read.localize(tester.l10n).toLowerCase(),
-          '/home/ubuntu/Downloads/file.txt',
+          'file.txt',
+          'Downloads',
         ),
       ),
       findsOneWidget,

--- a/flutter/apps/prompting_client_ui/test/test_utils.dart
+++ b/flutter/apps/prompting_client_ui/test/test_utils.dart
@@ -60,6 +60,7 @@ PromptDetails mockPromptDetailsHome({
   Set<HomePermission>? availablePermissions,
   Set<HomePermission>? suggestedPermissions,
   Set<PatternOption>? patternOptions,
+  EnrichedPathKind? enrichedPathKind,
 }) =>
     PromptDetails.home(
       metaData: MetaData(
@@ -75,6 +76,7 @@ PromptDetails mockPromptDetailsHome({
       availablePermissions: availablePermissions ?? {},
       suggestedPermissions: suggestedPermissions ?? {},
       patternOptions: patternOptions ?? {},
+      enrichedPathKind: enrichedPathKind ?? EnrichedPathKind.homeDir(),
     );
 
 PromptDetails registerMockPromptDetails({

--- a/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pb.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pb.dart
@@ -927,6 +927,7 @@ class HomePrompt extends $pb.GeneratedMessage {
     $core.Iterable<HomePermission>? suggestedPermissions,
     $core.Iterable<HomePrompt_PatternOption>? patternOptions,
     $core.int? initialPatternOption,
+    EnrichedPathKind? enrichedPathKind,
   }) {
     final $result = create();
     if (metaData != null) {
@@ -953,6 +954,9 @@ class HomePrompt extends $pb.GeneratedMessage {
     if (initialPatternOption != null) {
       $result.initialPatternOption = initialPatternOption;
     }
+    if (enrichedPathKind != null) {
+      $result.enrichedPathKind = enrichedPathKind;
+    }
     return $result;
   }
   HomePrompt._() : super();
@@ -968,6 +972,7 @@ class HomePrompt extends $pb.GeneratedMessage {
     ..pc<HomePermission>(6, _omitFieldNames ? '' : 'suggestedPermissions', $pb.PbFieldType.KE, valueOf: HomePermission.valueOf, enumValues: HomePermission.values, defaultEnumValue: HomePermission.READ)
     ..pc<HomePrompt_PatternOption>(7, _omitFieldNames ? '' : 'patternOptions', $pb.PbFieldType.PM, subBuilder: HomePrompt_PatternOption.create)
     ..a<$core.int>(8, _omitFieldNames ? '' : 'initialPatternOption', $pb.PbFieldType.O3)
+    ..aOM<EnrichedPathKind>(9, _omitFieldNames ? '' : 'enrichedPathKind', subBuilder: EnrichedPathKind.create)
     ..hasRequiredFields = false
   ;
 
@@ -1041,6 +1046,17 @@ class HomePrompt extends $pb.GeneratedMessage {
   $core.bool hasInitialPatternOption() => $_has(7);
   @$pb.TagNumber(8)
   void clearInitialPatternOption() => clearField(8);
+
+  @$pb.TagNumber(9)
+  EnrichedPathKind get enrichedPathKind => $_getN(8);
+  @$pb.TagNumber(9)
+  set enrichedPathKind(EnrichedPathKind v) { setField(9, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasEnrichedPathKind() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearEnrichedPathKind() => clearField(9);
+  @$pb.TagNumber(9)
+  EnrichedPathKind ensureEnrichedPathKind() => $_ensure(8);
 }
 
 class MetaData extends $pb.GeneratedMessage {
@@ -1247,6 +1263,421 @@ class SetLoggingFilterResponse extends $pb.GeneratedMessage {
   $core.bool hasCurrent() => $_has(0);
   @$pb.TagNumber(1)
   void clearCurrent() => clearField(1);
+}
+
+enum EnrichedPathKind_Kind {
+  homeDir, 
+  topLevelDir, 
+  subDir, 
+  homeDirFile, 
+  topLevelDirFile, 
+  subDirFile, 
+  notSet
+}
+
+class EnrichedPathKind extends $pb.GeneratedMessage {
+  factory EnrichedPathKind({
+    HomeDir? homeDir,
+    TopLevelDir? topLevelDir,
+    SubDir? subDir,
+    HomeDirFile? homeDirFile,
+    TopLevelDirFile? topLevelDirFile,
+    SubDirFile? subDirFile,
+  }) {
+    final $result = create();
+    if (homeDir != null) {
+      $result.homeDir = homeDir;
+    }
+    if (topLevelDir != null) {
+      $result.topLevelDir = topLevelDir;
+    }
+    if (subDir != null) {
+      $result.subDir = subDir;
+    }
+    if (homeDirFile != null) {
+      $result.homeDirFile = homeDirFile;
+    }
+    if (topLevelDirFile != null) {
+      $result.topLevelDirFile = topLevelDirFile;
+    }
+    if (subDirFile != null) {
+      $result.subDirFile = subDirFile;
+    }
+    return $result;
+  }
+  EnrichedPathKind._() : super();
+  factory EnrichedPathKind.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EnrichedPathKind.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static const $core.Map<$core.int, EnrichedPathKind_Kind> _EnrichedPathKind_KindByTag = {
+    1 : EnrichedPathKind_Kind.homeDir,
+    2 : EnrichedPathKind_Kind.topLevelDir,
+    3 : EnrichedPathKind_Kind.subDir,
+    4 : EnrichedPathKind_Kind.homeDirFile,
+    5 : EnrichedPathKind_Kind.topLevelDirFile,
+    6 : EnrichedPathKind_Kind.subDirFile,
+    0 : EnrichedPathKind_Kind.notSet
+  };
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EnrichedPathKind', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+    ..oo(0, [1, 2, 3, 4, 5, 6])
+    ..aOM<HomeDir>(1, _omitFieldNames ? '' : 'homeDir', subBuilder: HomeDir.create)
+    ..aOM<TopLevelDir>(2, _omitFieldNames ? '' : 'topLevelDir', subBuilder: TopLevelDir.create)
+    ..aOM<SubDir>(3, _omitFieldNames ? '' : 'subDir', subBuilder: SubDir.create)
+    ..aOM<HomeDirFile>(4, _omitFieldNames ? '' : 'homeDirFile', subBuilder: HomeDirFile.create)
+    ..aOM<TopLevelDirFile>(5, _omitFieldNames ? '' : 'topLevelDirFile', subBuilder: TopLevelDirFile.create)
+    ..aOM<SubDirFile>(6, _omitFieldNames ? '' : 'subDirFile', subBuilder: SubDirFile.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EnrichedPathKind clone() => EnrichedPathKind()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EnrichedPathKind copyWith(void Function(EnrichedPathKind) updates) => super.copyWith((message) => updates(message as EnrichedPathKind)) as EnrichedPathKind;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EnrichedPathKind create() => EnrichedPathKind._();
+  EnrichedPathKind createEmptyInstance() => create();
+  static $pb.PbList<EnrichedPathKind> createRepeated() => $pb.PbList<EnrichedPathKind>();
+  @$core.pragma('dart2js:noInline')
+  static EnrichedPathKind getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EnrichedPathKind>(create);
+  static EnrichedPathKind? _defaultInstance;
+
+  EnrichedPathKind_Kind whichKind() => _EnrichedPathKind_KindByTag[$_whichOneof(0)]!;
+  void clearKind() => clearField($_whichOneof(0));
+
+  @$pb.TagNumber(1)
+  HomeDir get homeDir => $_getN(0);
+  @$pb.TagNumber(1)
+  set homeDir(HomeDir v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasHomeDir() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearHomeDir() => clearField(1);
+  @$pb.TagNumber(1)
+  HomeDir ensureHomeDir() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  TopLevelDir get topLevelDir => $_getN(1);
+  @$pb.TagNumber(2)
+  set topLevelDir(TopLevelDir v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTopLevelDir() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTopLevelDir() => clearField(2);
+  @$pb.TagNumber(2)
+  TopLevelDir ensureTopLevelDir() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  SubDir get subDir => $_getN(2);
+  @$pb.TagNumber(3)
+  set subDir(SubDir v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSubDir() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSubDir() => clearField(3);
+  @$pb.TagNumber(3)
+  SubDir ensureSubDir() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  HomeDirFile get homeDirFile => $_getN(3);
+  @$pb.TagNumber(4)
+  set homeDirFile(HomeDirFile v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasHomeDirFile() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearHomeDirFile() => clearField(4);
+  @$pb.TagNumber(4)
+  HomeDirFile ensureHomeDirFile() => $_ensure(3);
+
+  @$pb.TagNumber(5)
+  TopLevelDirFile get topLevelDirFile => $_getN(4);
+  @$pb.TagNumber(5)
+  set topLevelDirFile(TopLevelDirFile v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasTopLevelDirFile() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearTopLevelDirFile() => clearField(5);
+  @$pb.TagNumber(5)
+  TopLevelDirFile ensureTopLevelDirFile() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  SubDirFile get subDirFile => $_getN(5);
+  @$pb.TagNumber(6)
+  set subDirFile(SubDirFile v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasSubDirFile() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearSubDirFile() => clearField(6);
+  @$pb.TagNumber(6)
+  SubDirFile ensureSubDirFile() => $_ensure(5);
+}
+
+class HomeDir extends $pb.GeneratedMessage {
+  factory HomeDir() => create();
+  HomeDir._() : super();
+  factory HomeDir.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory HomeDir.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'HomeDir', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  HomeDir clone() => HomeDir()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  HomeDir copyWith(void Function(HomeDir) updates) => super.copyWith((message) => updates(message as HomeDir)) as HomeDir;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static HomeDir create() => HomeDir._();
+  HomeDir createEmptyInstance() => create();
+  static $pb.PbList<HomeDir> createRepeated() => $pb.PbList<HomeDir>();
+  @$core.pragma('dart2js:noInline')
+  static HomeDir getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<HomeDir>(create);
+  static HomeDir? _defaultInstance;
+}
+
+class TopLevelDir extends $pb.GeneratedMessage {
+  factory TopLevelDir({
+    $core.String? dirname,
+  }) {
+    final $result = create();
+    if (dirname != null) {
+      $result.dirname = dirname;
+    }
+    return $result;
+  }
+  TopLevelDir._() : super();
+  factory TopLevelDir.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TopLevelDir.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TopLevelDir', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'dirname')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TopLevelDir clone() => TopLevelDir()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TopLevelDir copyWith(void Function(TopLevelDir) updates) => super.copyWith((message) => updates(message as TopLevelDir)) as TopLevelDir;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TopLevelDir create() => TopLevelDir._();
+  TopLevelDir createEmptyInstance() => create();
+  static $pb.PbList<TopLevelDir> createRepeated() => $pb.PbList<TopLevelDir>();
+  @$core.pragma('dart2js:noInline')
+  static TopLevelDir getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TopLevelDir>(create);
+  static TopLevelDir? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get dirname => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set dirname($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDirname() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDirname() => clearField(1);
+}
+
+class SubDir extends $pb.GeneratedMessage {
+  factory SubDir() => create();
+  SubDir._() : super();
+  factory SubDir.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SubDir.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SubDir', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SubDir clone() => SubDir()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SubDir copyWith(void Function(SubDir) updates) => super.copyWith((message) => updates(message as SubDir)) as SubDir;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SubDir create() => SubDir._();
+  SubDir createEmptyInstance() => create();
+  static $pb.PbList<SubDir> createRepeated() => $pb.PbList<SubDir>();
+  @$core.pragma('dart2js:noInline')
+  static SubDir getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SubDir>(create);
+  static SubDir? _defaultInstance;
+}
+
+class HomeDirFile extends $pb.GeneratedMessage {
+  factory HomeDirFile({
+    $core.String? filename,
+  }) {
+    final $result = create();
+    if (filename != null) {
+      $result.filename = filename;
+    }
+    return $result;
+  }
+  HomeDirFile._() : super();
+  factory HomeDirFile.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory HomeDirFile.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'HomeDirFile', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'filename')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  HomeDirFile clone() => HomeDirFile()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  HomeDirFile copyWith(void Function(HomeDirFile) updates) => super.copyWith((message) => updates(message as HomeDirFile)) as HomeDirFile;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static HomeDirFile create() => HomeDirFile._();
+  HomeDirFile createEmptyInstance() => create();
+  static $pb.PbList<HomeDirFile> createRepeated() => $pb.PbList<HomeDirFile>();
+  @$core.pragma('dart2js:noInline')
+  static HomeDirFile getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<HomeDirFile>(create);
+  static HomeDirFile? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get filename => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set filename($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasFilename() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearFilename() => clearField(1);
+}
+
+class TopLevelDirFile extends $pb.GeneratedMessage {
+  factory TopLevelDirFile({
+    $core.String? dirname,
+    $core.String? filename,
+  }) {
+    final $result = create();
+    if (dirname != null) {
+      $result.dirname = dirname;
+    }
+    if (filename != null) {
+      $result.filename = filename;
+    }
+    return $result;
+  }
+  TopLevelDirFile._() : super();
+  factory TopLevelDirFile.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TopLevelDirFile.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TopLevelDirFile', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'dirname')
+    ..aOS(2, _omitFieldNames ? '' : 'filename')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TopLevelDirFile clone() => TopLevelDirFile()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TopLevelDirFile copyWith(void Function(TopLevelDirFile) updates) => super.copyWith((message) => updates(message as TopLevelDirFile)) as TopLevelDirFile;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TopLevelDirFile create() => TopLevelDirFile._();
+  TopLevelDirFile createEmptyInstance() => create();
+  static $pb.PbList<TopLevelDirFile> createRepeated() => $pb.PbList<TopLevelDirFile>();
+  @$core.pragma('dart2js:noInline')
+  static TopLevelDirFile getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TopLevelDirFile>(create);
+  static TopLevelDirFile? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get dirname => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set dirname($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDirname() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDirname() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get filename => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set filename($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFilename() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFilename() => clearField(2);
+}
+
+class SubDirFile extends $pb.GeneratedMessage {
+  factory SubDirFile() => create();
+  SubDirFile._() : super();
+  factory SubDirFile.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SubDirFile.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SubDirFile', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SubDirFile clone() => SubDirFile()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SubDirFile copyWith(void Function(SubDirFile) updates) => super.copyWith((message) => updates(message as SubDirFile)) as SubDirFile;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SubDirFile create() => SubDirFile._();
+  SubDirFile createEmptyInstance() => create();
+  static $pb.PbList<SubDirFile> createRepeated() => $pb.PbList<SubDirFile>();
+  @$core.pragma('dart2js:noInline')
+  static SubDirFile getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SubDirFile>(create);
+  static SubDirFile? _defaultInstance;
 }
 
 

--- a/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pbjson.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pbjson.dart
@@ -246,6 +246,7 @@ const HomePrompt$json = {
     {'1': 'suggested_permissions', '3': 6, '4': 3, '5': 14, '6': '.apparmor_prompting.HomePermission', '10': 'suggestedPermissions'},
     {'1': 'pattern_options', '3': 7, '4': 3, '5': 11, '6': '.apparmor_prompting.HomePrompt.PatternOption', '10': 'patternOptions'},
     {'1': 'initial_pattern_option', '3': 8, '4': 1, '5': 5, '10': 'initialPatternOption'},
+    {'1': 'enriched_path_kind', '3': 9, '4': 1, '5': 11, '6': '.apparmor_prompting.EnrichedPathKind', '10': 'enrichedPathKind'},
   ],
   '3': [HomePrompt_PatternOption$json],
 };
@@ -271,10 +272,12 @@ final $typed_data.Uint8List homePromptDescriptor = $convert.base64Decode(
     'aXNzaW9ucxgGIAMoDjIiLmFwcGFybW9yX3Byb21wdGluZy5Ib21lUGVybWlzc2lvblIUc3VnZ2'
     'VzdGVkUGVybWlzc2lvbnMSVQoPcGF0dGVybl9vcHRpb25zGAcgAygLMiwuYXBwYXJtb3JfcHJv'
     'bXB0aW5nLkhvbWVQcm9tcHQuUGF0dGVybk9wdGlvblIOcGF0dGVybk9wdGlvbnMSNAoWaW5pdG'
-    'lhbF9wYXR0ZXJuX29wdGlvbhgIIAEoBVIUaW5pdGlhbFBhdHRlcm5PcHRpb24aqgEKDVBhdHRl'
-    'cm5PcHRpb24STwoRaG9tZV9wYXR0ZXJuX3R5cGUYASABKA4yIy5hcHBhcm1vcl9wcm9tcHRpbm'
-    'cuSG9tZVBhdHRlcm5UeXBlUg9ob21lUGF0dGVyblR5cGUSIQoMcGF0aF9wYXR0ZXJuGAIgASgJ'
-    'UgtwYXRoUGF0dGVybhIlCg5zaG93X2luaXRpYWxseRgDIAEoCFINc2hvd0luaXRpYWxseQ==');
+    'lhbF9wYXR0ZXJuX29wdGlvbhgIIAEoBVIUaW5pdGlhbFBhdHRlcm5PcHRpb24SUgoSZW5yaWNo'
+    'ZWRfcGF0aF9raW5kGAkgASgLMiQuYXBwYXJtb3JfcHJvbXB0aW5nLkVucmljaGVkUGF0aEtpbm'
+    'RSEGVucmljaGVkUGF0aEtpbmQaqgEKDVBhdHRlcm5PcHRpb24STwoRaG9tZV9wYXR0ZXJuX3R5'
+    'cGUYASABKA4yIy5hcHBhcm1vcl9wcm9tcHRpbmcuSG9tZVBhdHRlcm5UeXBlUg9ob21lUGF0dG'
+    'VyblR5cGUSIQoMcGF0aF9wYXR0ZXJuGAIgASgJUgtwYXRoUGF0dGVybhIlCg5zaG93X2luaXRp'
+    'YWxseRgDIAEoCFINc2hvd0luaXRpYWxseQ==');
 
 @$core.Deprecated('Use metaDataDescriptor instead')
 const MetaData$json = {
@@ -319,4 +322,96 @@ const SetLoggingFilterResponse$json = {
 /// Descriptor for `SetLoggingFilterResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List setLoggingFilterResponseDescriptor = $convert.base64Decode(
     'ChhTZXRMb2dnaW5nRmlsdGVyUmVzcG9uc2USGAoHY3VycmVudBgBIAEoCVIHY3VycmVudA==');
+
+@$core.Deprecated('Use enrichedPathKindDescriptor instead')
+const EnrichedPathKind$json = {
+  '1': 'EnrichedPathKind',
+  '2': [
+    {'1': 'home_dir', '3': 1, '4': 1, '5': 11, '6': '.apparmor_prompting.HomeDir', '9': 0, '10': 'homeDir'},
+    {'1': 'top_level_dir', '3': 2, '4': 1, '5': 11, '6': '.apparmor_prompting.TopLevelDir', '9': 0, '10': 'topLevelDir'},
+    {'1': 'sub_dir', '3': 3, '4': 1, '5': 11, '6': '.apparmor_prompting.SubDir', '9': 0, '10': 'subDir'},
+    {'1': 'home_dir_file', '3': 4, '4': 1, '5': 11, '6': '.apparmor_prompting.HomeDirFile', '9': 0, '10': 'homeDirFile'},
+    {'1': 'top_level_dir_file', '3': 5, '4': 1, '5': 11, '6': '.apparmor_prompting.TopLevelDirFile', '9': 0, '10': 'topLevelDirFile'},
+    {'1': 'sub_dir_file', '3': 6, '4': 1, '5': 11, '6': '.apparmor_prompting.SubDirFile', '9': 0, '10': 'subDirFile'},
+  ],
+  '8': [
+    {'1': 'kind'},
+  ],
+};
+
+/// Descriptor for `EnrichedPathKind`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List enrichedPathKindDescriptor = $convert.base64Decode(
+    'ChBFbnJpY2hlZFBhdGhLaW5kEjgKCGhvbWVfZGlyGAEgASgLMhsuYXBwYXJtb3JfcHJvbXB0aW'
+    '5nLkhvbWVEaXJIAFIHaG9tZURpchJFCg10b3BfbGV2ZWxfZGlyGAIgASgLMh8uYXBwYXJtb3Jf'
+    'cHJvbXB0aW5nLlRvcExldmVsRGlySABSC3RvcExldmVsRGlyEjUKB3N1Yl9kaXIYAyABKAsyGi'
+    '5hcHBhcm1vcl9wcm9tcHRpbmcuU3ViRGlySABSBnN1YkRpchJFCg1ob21lX2Rpcl9maWxlGAQg'
+    'ASgLMh8uYXBwYXJtb3JfcHJvbXB0aW5nLkhvbWVEaXJGaWxlSABSC2hvbWVEaXJGaWxlElIKEn'
+    'RvcF9sZXZlbF9kaXJfZmlsZRgFIAEoCzIjLmFwcGFybW9yX3Byb21wdGluZy5Ub3BMZXZlbERp'
+    'ckZpbGVIAFIPdG9wTGV2ZWxEaXJGaWxlEkIKDHN1Yl9kaXJfZmlsZRgGIAEoCzIeLmFwcGFybW'
+    '9yX3Byb21wdGluZy5TdWJEaXJGaWxlSABSCnN1YkRpckZpbGVCBgoEa2luZA==');
+
+@$core.Deprecated('Use homeDirDescriptor instead')
+const HomeDir$json = {
+  '1': 'HomeDir',
+};
+
+/// Descriptor for `HomeDir`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List homeDirDescriptor = $convert.base64Decode(
+    'CgdIb21lRGly');
+
+@$core.Deprecated('Use topLevelDirDescriptor instead')
+const TopLevelDir$json = {
+  '1': 'TopLevelDir',
+  '2': [
+    {'1': 'dirname', '3': 1, '4': 1, '5': 9, '10': 'dirname'},
+  ],
+};
+
+/// Descriptor for `TopLevelDir`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List topLevelDirDescriptor = $convert.base64Decode(
+    'CgtUb3BMZXZlbERpchIYCgdkaXJuYW1lGAEgASgJUgdkaXJuYW1l');
+
+@$core.Deprecated('Use subDirDescriptor instead')
+const SubDir$json = {
+  '1': 'SubDir',
+};
+
+/// Descriptor for `SubDir`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List subDirDescriptor = $convert.base64Decode(
+    'CgZTdWJEaXI=');
+
+@$core.Deprecated('Use homeDirFileDescriptor instead')
+const HomeDirFile$json = {
+  '1': 'HomeDirFile',
+  '2': [
+    {'1': 'filename', '3': 1, '4': 1, '5': 9, '10': 'filename'},
+  ],
+};
+
+/// Descriptor for `HomeDirFile`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List homeDirFileDescriptor = $convert.base64Decode(
+    'CgtIb21lRGlyRmlsZRIaCghmaWxlbmFtZRgBIAEoCVIIZmlsZW5hbWU=');
+
+@$core.Deprecated('Use topLevelDirFileDescriptor instead')
+const TopLevelDirFile$json = {
+  '1': 'TopLevelDirFile',
+  '2': [
+    {'1': 'dirname', '3': 1, '4': 1, '5': 9, '10': 'dirname'},
+    {'1': 'filename', '3': 2, '4': 1, '5': 9, '10': 'filename'},
+  ],
+};
+
+/// Descriptor for `TopLevelDirFile`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List topLevelDirFileDescriptor = $convert.base64Decode(
+    'Cg9Ub3BMZXZlbERpckZpbGUSGAoHZGlybmFtZRgBIAEoCVIHZGlybmFtZRIaCghmaWxlbmFtZR'
+    'gCIAEoCVIIZmlsZW5hbWU=');
+
+@$core.Deprecated('Use subDirFileDescriptor instead')
+const SubDirFile$json = {
+  '1': 'SubDirFile',
+};
+
+/// Descriptor for `SubDirFile`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List subDirFileDescriptor = $convert.base64Decode(
+    'CgpTdWJEaXJGaWxl');
 

--- a/flutter/packages/prompting_client/lib/src/prompting_client.dart
+++ b/flutter/packages/prompting_client/lib/src/prompting_client.dart
@@ -110,6 +110,27 @@ extension PermissionConversion on HomePermission {
       };
 }
 
+extension EnrichedPathKindConversion on EnrichedPathKind {
+  static EnrichedPathKind fromProto(pb.EnrichedPathKind kind) =>
+      switch (kind.whichKind()) {
+        pb.EnrichedPathKind_Kind.homeDir => EnrichedPathKind.homeDir(),
+        pb.EnrichedPathKind_Kind.topLevelDir => EnrichedPathKind.topLevelDir(
+            dirname: kind.topLevelDir.dirname,
+          ),
+        pb.EnrichedPathKind_Kind.subDir => EnrichedPathKind.subDir(),
+        pb.EnrichedPathKind_Kind.homeDirFile => EnrichedPathKind.homeDirFile(
+            filename: kind.homeDirFile.filename,
+          ),
+        pb.EnrichedPathKind_Kind.topLevelDirFile =>
+          EnrichedPathKind.topLevelDirFile(
+            dirname: kind.topLevelDirFile.dirname,
+            filename: kind.topLevelDirFile.filename,
+          ),
+        pb.EnrichedPathKind_Kind.subDirFile => EnrichedPathKind.subDirFile(),
+        pb.EnrichedPathKind_Kind.notSet => throw ArgumentError('Unknown kind'),
+      };
+}
+
 extension PrompteDetailsConversion on PromptDetails {
   static PromptDetails fromProto(pb.GetCurrentPromptResponse response) =>
       switch (response.whichPrompt()) {
@@ -131,6 +152,9 @@ extension PrompteDetailsConversion on PromptDetails {
                 .map(MoreOptionConversion.fromProto)
                 .toSet(),
             initialPatternOption: response.homePrompt.initialPatternOption,
+            enrichedPathKind: EnrichedPathKindConversion.fromProto(
+              response.homePrompt.enrichedPathKind,
+            ),
           ),
         pb.GetCurrentPromptResponse_Prompt.notSet =>
           throw ArgumentError('Prompt type not set'),

--- a/flutter/packages/prompting_client/lib/src/prompting_models.dart
+++ b/flutter/packages/prompting_client/lib/src/prompting_models.dart
@@ -50,6 +50,31 @@ class PatternOption with _$PatternOption {
 }
 
 @freezed
+class EnrichedPathKind with _$EnrichedPathKind {
+  factory EnrichedPathKind.homeDir() = EnrichedPathKindHomeDir;
+
+  factory EnrichedPathKind.topLevelDir({
+    required String dirname,
+  }) = EnrichedPathKindTopLevelDir;
+
+  factory EnrichedPathKind.subDir() = EnrichedPathKindSubDir;
+
+  factory EnrichedPathKind.homeDirFile({
+    required String filename,
+  }) = EnrichedPathKindHomeDirFile;
+
+  factory EnrichedPathKind.topLevelDirFile({
+    required String dirname,
+    required String filename,
+  }) = EnrichedPathKindTopLevelDirFile;
+
+  factory EnrichedPathKind.subDirFile() = EnrichedPathKindSubDirFile;
+
+  factory EnrichedPathKind.fromJson(Map<String, dynamic> json) =>
+      _$EnrichedPathKindFromJson(json);
+}
+
+@freezed
 sealed class PromptDetails with _$PromptDetails {
   factory PromptDetails.home({
     required MetaData metaData,
@@ -59,6 +84,7 @@ sealed class PromptDetails with _$PromptDetails {
     required Set<HomePermission> availablePermissions,
     required Set<HomePermission> suggestedPermissions,
     required Set<PatternOption> patternOptions,
+    required EnrichedPathKind enrichedPathKind,
     @Default(0) int initialPatternOption,
   }) = PromptDetailsHome;
 

--- a/flutter/packages/prompting_client/lib/src/prompting_models.dart
+++ b/flutter/packages/prompting_client/lib/src/prompting_models.dart
@@ -50,7 +50,7 @@ class PatternOption with _$PatternOption {
 }
 
 @freezed
-class EnrichedPathKind with _$EnrichedPathKind {
+sealed class EnrichedPathKind with _$EnrichedPathKind {
   factory EnrichedPathKind.homeDir() = EnrichedPathKindHomeDir;
 
   factory EnrichedPathKind.topLevelDir({

--- a/flutter/packages/prompting_client/test/prompting_client_test.dart
+++ b/flutter/packages/prompting_client/test/prompting_client_test.dart
@@ -40,6 +40,9 @@ void main() {
           ),
         ],
         initialPatternOption: 0,
+        enrichedPathKind: pb.EnrichedPathKind(
+          homeDir: pb.HomeDir(),
+        ),
       ),
     )..freeze();
     final testCases = [
@@ -69,6 +72,7 @@ void main() {
               pathPattern: '/home/user/Downloads/**',
             ),
           },
+          enrichedPathKind: EnrichedPathKind.homeDir(),
         ),
         expectError: false,
       ),

--- a/prompting-client/src/protos/apparmor_prompting.rs
+++ b/prompting-client/src/protos/apparmor_prompting.rs
@@ -150,6 +150,8 @@ pub struct HomePrompt {
     pub pattern_options: ::prost::alloc::vec::Vec<home_prompt::PatternOption>,
     #[prost(int32, tag = "8")]
     pub initial_pattern_option: i32,
+    #[prost(message, optional, tag = "9")]
+    pub enriched_path_kind: ::core::option::Option<EnrichedPathKind>,
 }
 /// Nested message and enum types in `HomePrompt`.
 pub mod home_prompt {
@@ -190,6 +192,60 @@ pub struct SetLoggingFilterResponse {
     #[prost(string, tag = "1")]
     pub current: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnrichedPathKind {
+    #[prost(oneof = "enriched_path_kind::Kind", tags = "1, 2, 3, 4, 5, 6")]
+    pub kind: ::core::option::Option<enriched_path_kind::Kind>,
+}
+/// Nested message and enum types in `EnrichedPathKind`.
+pub mod enriched_path_kind {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Kind {
+        #[prost(message, tag = "1")]
+        HomeDir(super::HomeDir),
+        #[prost(message, tag = "2")]
+        TopLevelDir(super::TopLevelDir),
+        #[prost(message, tag = "3")]
+        SubDir(super::SubDir),
+        #[prost(message, tag = "4")]
+        HomeDirFile(super::HomeDirFile),
+        #[prost(message, tag = "5")]
+        TopLevelDirFile(super::TopLevelDirFile),
+        #[prost(message, tag = "6")]
+        SubDirFile(super::SubDirFile),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct HomeDir {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TopLevelDir {
+    #[prost(string, tag = "1")]
+    pub dirname: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct SubDir {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HomeDirFile {
+    #[prost(string, tag = "1")]
+    pub filename: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TopLevelDirFile {
+    #[prost(string, tag = "1")]
+    pub dirname: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub filename: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct SubDirFile {}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Action {

--- a/prompting-client/src/snapd_client/interfaces/home.rs
+++ b/prompting-client/src/snapd_client/interfaces/home.rs
@@ -496,7 +496,7 @@ impl<'a> CategorisedPath<'a> {
             PathKind::TopLevelDir | PathKind::TopLevelDirFile
         ));
         let top_level: PathBuf = self.path.iter().take(1).collect();
-        top_level.to_string_lossy().to_owned().to_string()
+        top_level.to_string_lossy().into_owned().to_string()
     }
 
     fn get_file_name(&self) -> String {
@@ -505,7 +505,7 @@ impl<'a> CategorisedPath<'a> {
             PathKind::HomeDirFile | PathKind::TopLevelDirFile
         ));
         let file: PathBuf = self.path.iter().last().into_iter().collect();
-        file.to_string_lossy().to_owned().to_string()
+        file.to_string_lossy().into_owned().to_string()
     }
 }
 

--- a/prompting-client/src/snapd_client/interfaces/home.rs
+++ b/prompting-client/src/snapd_client/interfaces/home.rs
@@ -60,6 +60,7 @@ impl PromptReply<HomeInterface> {
 pub struct HomeInterface;
 
 struct PatternOptions {
+    enriched_path_kind: EnrichedPathKind,
     initial_pattern_option: usize,
     pattern_options: Vec<TypedPathPattern>,
 }
@@ -111,6 +112,22 @@ impl PatternOptions {
             ],
         };
 
+        let enriched_path_kind = match cpath.kind {
+            PathKind::HomeDir => EnrichedPathKind::HomeDir,
+            PathKind::TopLevelDir => EnrichedPathKind::TopLevelDir {
+                dirname: cpath.get_top_level_dir(),
+            },
+            PathKind::SubDir => EnrichedPathKind::SubDir,
+            PathKind::HomeDirFile => EnrichedPathKind::HomeDirFile {
+                filename: cpath.get_file_name(),
+            },
+            PathKind::TopLevelDirFile => EnrichedPathKind::TopLevelDirFile {
+                dirname: cpath.get_top_level_dir(),
+                filename: cpath.get_file_name(),
+            },
+            PathKind::SubDirFile => EnrichedPathKind::SubDirFile,
+        };
+
         if !cpath.is_dir {
             if let Some(opt) = cpath.matching_extension_pattern() {
                 options.push(opt);
@@ -118,6 +135,7 @@ impl PatternOptions {
         }
 
         Ok(Self {
+            enriched_path_kind,
             initial_pattern_option: 1,
             pattern_options: options,
         })
@@ -164,6 +182,7 @@ impl SnapInterface for HomeInterface {
         let PatternOptions {
             initial_pattern_option,
             pattern_options,
+            enriched_path_kind,
         } = self.ui_options(&prompt)?;
         let meta = meta.unwrap_or_else(|| SnapMeta {
             name: prompt.snap,
@@ -191,6 +210,7 @@ impl SnapInterface for HomeInterface {
                 suggested_permissions,
                 pattern_options,
                 initial_pattern_option,
+                enriched_path_kind,
             },
         })
     }
@@ -220,6 +240,7 @@ pub struct HomeUiInputData {
     pub(crate) suggested_permissions: Vec<String>,
     pub(crate) initial_pattern_option: usize,
     pub(crate) pattern_options: Vec<TypedPathPattern>,
+    pub(crate) enriched_path_kind: EnrichedPathKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -346,6 +367,17 @@ impl ReplyConstraintsOverrides for HomeReplyConstraintsOverrides {
     }
 }
 
+/// PathKind's enriched with file names and directory names when needed for templating in the prompting UI.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EnrichedPathKind {
+    HomeDir,
+    TopLevelDir { dirname: String },
+    SubDir,
+    HomeDirFile { filename: String },
+    TopLevelDirFile { dirname: String, filename: String },
+    SubDirFile,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PathKind {
     HomeDir,
@@ -456,6 +488,24 @@ impl<'a> CategorisedPath<'a> {
             }
             _ => None,
         }
+    }
+
+    fn get_top_level_dir(&self) -> String {
+        debug_assert!(matches!(
+            self.kind,
+            PathKind::TopLevelDir | PathKind::TopLevelDirFile
+        ));
+        let top_level: PathBuf = self.path.iter().take(1).collect();
+        format!("{}", top_level.to_string_lossy())
+    }
+
+    fn get_file_name(&self) -> String {
+        debug_assert!(matches!(
+            self.kind,
+            PathKind::HomeDirFile | PathKind::TopLevelDirFile
+        ));
+        let file: PathBuf = self.path.iter().last().into_iter().collect();
+        format!("{}", file.to_string_lossy())
     }
 }
 

--- a/prompting-client/src/snapd_client/interfaces/home.rs
+++ b/prompting-client/src/snapd_client/interfaces/home.rs
@@ -496,7 +496,7 @@ impl<'a> CategorisedPath<'a> {
             PathKind::TopLevelDir | PathKind::TopLevelDirFile
         ));
         let top_level: PathBuf = self.path.iter().take(1).collect();
-        format!("{}", top_level.to_string_lossy())
+        top_level.to_string_lossy().to_owned().to_string()
     }
 
     fn get_file_name(&self) -> String {
@@ -505,7 +505,7 @@ impl<'a> CategorisedPath<'a> {
             PathKind::HomeDirFile | PathKind::TopLevelDirFile
         ));
         let file: PathBuf = self.path.iter().last().into_iter().collect();
-        format!("{}", file.to_string_lossy())
+        file.to_string_lossy().to_owned().to_string()
     }
 }
 

--- a/protos/apparmor-prompting.proto
+++ b/protos/apparmor-prompting.proto
@@ -108,7 +108,8 @@ message HomePrompt {
         HomePatternType home_pattern_type = 1;
         string path_pattern = 2;
         bool show_initially = 3;
-    }
+    };
+    EnrichedPathKind enriched_path_kind = 9;
 }
 
 enum HomePatternType {
@@ -136,3 +137,33 @@ message ResolveHomePatternTypeResponse {
 message SetLoggingFilterResponse {
     string current = 1;
 }
+
+message EnrichedPathKind {
+  oneof kind {
+    HomeDir home_dir = 1;
+    TopLevelDir top_level_dir = 2;
+    SubDir sub_dir = 3;
+    HomeDirFile home_dir_file = 4;
+    TopLevelDirFile top_level_dir_file = 5;
+    SubDirFile sub_dir_file = 6;
+  }
+}
+
+message HomeDir {}
+
+message TopLevelDir {
+  string dirname = 1;
+}
+
+message SubDir {}
+
+message HomeDirFile {
+  string filename = 1;
+}
+
+message TopLevelDirFile {
+  string dirname = 1;
+  string filename = 2;
+}
+
+message SubDirFile {}


### PR DESCRIPTION
Updates prompting messaging to align with MVP designs: https://www.figma.com/board/1DIGbaCf4ZjTcShYjLiAIi/24.10-AppArmor-prompting---MVP-logic?node-id=0-1&node-type=canvas&t=5IUl7Ys94lcOdA9J-0

Namely, messaging is now dependent on if a folder or file is being asked for, and where in relation to the users home directory it is. There are 5 variations we consider:
- Asking for permissions to the users Home directory
![Screenshot From 2024-12-12 17-16-34](https://github.com/user-attachments/assets/c419e11f-eea2-4224-b116-73a2cae0a2ef)

- Asking for permissions to a file within the Home directory
![Screenshot From 2024-12-12 17-17-53](https://github.com/user-attachments/assets/00493aa5-306d-4a23-9afa-34d3aa05f277)

- Asking for permissions to a Folder in the home directory (a top level folder)
![Screenshot From 2024-12-12 17-15-35](https://github.com/user-attachments/assets/0c57c896-4392-439f-9f5e-ec6b78ec4764)

- Asking for permissions to a file with within a top level folder
![Screenshot From 2024-12-12 17-27-21](https://github.com/user-attachments/assets/fc5c3016-d426-47df-bcd6-0f0633bec37d)

- Asking for permissions to a folder or file nested more deeply than a top level folder
![Screenshot From 2024-12-12 17-18-29](https://github.com/user-attachments/assets/1bcde238-c350-45d2-990c-7c309eac3022)

The type of path that is being requested, as well as relevant file and folder used in the templating, is piped to the UI via a new Rust type, `EnrichedPathKind`: https://github.com/canonical/prompting-client/pull/152/files#diff-9e62b451f6f35c1a9d0a981c28c2514d43cbec583e546f05510f260670bd84ebR372