### PR TITLE
chore: setting up TiCS CI integration

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -28,6 +28,7 @@ jobs:
       - run: melos generate
       - run: melos gen-l10n
       - run: melos coverage
+      - run: melos build
 
       - name: Run TICS analysis
         if: github.event_name == 'push'

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: Atsumi3/actions-setup-fvm@0.0.3
       - uses: bluefireteam/melos-action@v3
       - name: Install dependencies
-        run: sudo apt update && sudo apt install -y protobuf-compiler lcov clang cmake curl libgtk-3-dev ninja-build pkg-config unzip
+        run: sudo apt update && sudo apt install -y protobuf-compiler lcov clang cmake curl libgtk-3-dev ninja-build pkg-config unzip libglib2.0-dev liblzma-dev xvfb
       - run: melos generate
       - run: melos gen-l10n
       - run: melos coverage

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -2,11 +2,11 @@ name: TICS
 
 on:
   push:
-    # branches:
-    #   - main
-  # pull_request:
-    # branches:
-    #   - main
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -25,10 +25,24 @@ jobs:
       - uses: bluefireteam/melos-action@v3
       - name: Install dependencies
         run: sudo apt update && sudo apt install -y protobuf-compiler lcov clang cmake curl libgtk-3-dev ninja-build pkg-config unzip libglib2.0-dev liblzma-dev xvfb
+      - run: dart pub global activate cobertura
       - run: melos generate
       - run: melos gen-l10n
       - run: melos coverage
       - run: melos build
+      - run: |
+          mkdir .coverage
+          pushd flutter/packages/prompting_client
+          cobertura convert
+          sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
+          mv coverage/cobertura.xml ../../../.coverage/prompting_client.xml
+          popd
+
+          pushd flutter/apps/prompting_client_ui
+          cobertura convert
+          sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
+          mv coverage/cobertura.xml ../../../.coverage/prompting_client_ui.xml
+          popd
 
       - name: Run TICS analysis
         if: github.event_name == 'push'

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: Atsumi3/actions-setup-fvm@0.0.3
       - uses: bluefireteam/melos-action@v3
       - name: Install dependencies
-        run: sudo apt update && sudo apt install -y protobuf-compiler lcov clang cmake curl libgtk-3-dev ninja-build pkg-config unzip libglib2.0-dev liblzma-dev xvfb
+        run: sudo apt update && sudo apt install -y protobuf-compiler lcov clang cmake curl libgtk-3-dev ninja-build pkg-config unzip libglib2.0-dev liblzma-dev
       - run: dart pub global activate cobertura
       - run: melos generate
       - run: melos gen-l10n

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -1,0 +1,37 @@
+name: TICS
+
+on:
+  push:
+    # branches:
+    #   - main
+  # pull_request:
+    # branches:
+    #   - main
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_LOG: info
+  RUST_BACKTRACE: 1
+
+jobs:
+  tics:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y protobuf-compiler
+
+      - name: Run TICS analysis
+        if: github.event_name == 'push'
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: prompting-client
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true
+          branchname: main

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -21,9 +21,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: bluefireteam/melos-action@v3
       - name: Install dependencies
-        run: |
-          sudo apt update && sudo apt install -y protobuf-compiler
+        run: sudo apt update && sudo apt install -y protobuf-compiler lcov clang cmake curl libgtk-3-dev ninja-build pkg-config unzip
+      - run: melos generate
+      - run: melos gen-l10n
+      - run: melos coverage
 
       - name: Run TICS analysis
         if: github.event_name == 'push'

--- a/melos.yaml
+++ b/melos.yaml
@@ -34,6 +34,7 @@ scripts:
         '**/*.mocks.dart' \
         '**/l10n/*.dart' \
         '**/*.pb*.dart' \
+        --ignore-errors unused,unused \
         -o coverage/lcov.info
 
   # format all packages


### PR DESCRIPTION
This is now hooked up and "working" for a given definition of working (a green run can be found [here](https://github.com/canonical/prompting-client/actions/runs/13160779575)).

For some reason, TiCS is reporting that it can find coverage for some files in the project (such as `flutter/apps/prompting_client_ui/lib/l10n.dart`) but not others when they are contained in the same coverage file (such as `flutter/apps/prompting_client_ui/lib/l10n_x.dart`). From what I can see locally when generating the coverage I'd expect it to find neither or both, and all I can see that is different in the output from the workflow run is that the files which _are_ found have a `(recheck)` suffix to their relevant log lines.

Interestingly the files in the `flutter/packages` seem to be processed correctly so I am wondering if this might be a configuration issue on the TiCS side? But then that doesn't explain why some of the files under `flutter/apps` _are_ picked up :shrug:

I've tried adding the manual conversion to the Cobertura XML format as covered by Security in their docs, placing the resulting files in a `.coverage` directory in the root of the repo but that doesn't appear to have helped. I've left this in for now given that the docs call out handling it explicitly but we will need to chase things up to see what it is we are missing.

:crab: There is then also the issue that TiCS is not currently looking at the Rust code at all which also needs chasing up. :crab:

---

For future reference, in the case described above the relevant section of `flutter/apps/prompting_client_ui/coverage/lcov.info` looks like this:
```
...
TN:
SF:lib/l10n.dart
FNF:0
FNH:0
DA:8,0
DA:9,0
DA:10,0
DA:11,0
LF:4
LH:0
end_of_record
TN:
SF:lib/l10n_x.dart
FNF:0
FNH:0
DA:5,1
DA:6,2
DA:7,2
DA:12,1
DA:13,2
DA:14,1
DA:15,2
DA:20,4
DA:21,4
DA:22,2
DA:23,2
DA:24,4
DA:25,2
DA:26,2
DA:27,10
DA:29,2
DA:30,2
DA:31,4
DA:32,2
DA:33,2
DA:34,8
DA:36,2
DA:37,2
DA:42,1
DA:43,2
DA:44,2
DA:45,2
LF:27
LH:27
end_of_record
...
```