### PR TITLE
feat: add high contrast theme

### DIFF
--- a/flutter/apps/prompting_client_ui/lib/main.dart
+++ b/flutter/apps/prompting_client_ui/lib/main.dart
@@ -80,6 +80,8 @@ class PromptDialog extends StatelessWidget {
       builder: (context, yaru, child) => MaterialApp(
         theme: yaru.theme?.customize(),
         darkTheme: yaru.darkTheme?.customize(),
+        highContrastTheme: yaruHighContrastLight.customize(),
+        highContrastDarkTheme: yaruHighContrastDark.customize(),
         debugShowCheckedModeBanner: false,
         localizationsDelegates: localizationsDelegates,
         supportedLocales: supportedLocales,


### PR DESCRIPTION
Adds the missing high contrast theme for the prompting UI

![Screenshot From 2025-02-06 16-38-07](https://github.com/user-attachments/assets/65a5209f-01c8-4ff0-b8d5-e7c8b36ccfbd)
![Screenshot From 2025-02-06 16-38-01](https://github.com/user-attachments/assets/48ba3909-9c7a-4559-ad61-8f5d03550e5d)
