### PR TITLE
ci(tics): update coverage dir and remove XML conversion

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -25,7 +25,6 @@ jobs:
       - uses: bluefireteam/melos-action@v3
       - name: Install dependencies
         run: sudo apt update && sudo apt install -y protobuf-compiler lcov clang cmake curl libgtk-3-dev ninja-build pkg-config unzip libglib2.0-dev liblzma-dev
-      - run: dart pub global activate cobertura
       - run: melos generate
       - run: melos gen-l10n
       - run: melos coverage
@@ -33,20 +32,12 @@ jobs:
       - run: |
           mkdir coverage
           pushd flutter/packages/prompting_client
-          cobertura convert
-          sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
-          sed -i "s|lib/|$(pwd)/lib/|g" coverage/cobertura.xml
           sed -i "s|lib/|$(pwd)/lib/|g" coverage/lcov.info
-          mv coverage/cobertura.xml ../../../coverage/prompting_client.xml
           mv coverage/lcov.info ../../../coverage/prompting_client.info
           popd
 
           pushd flutter/apps/prompting_client_ui
-          cobertura convert
-          sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
-          sed -i "s|lib/|$(pwd)/lib/|g" coverage/cobertura.xml
           sed -i "s|lib/|$(pwd)/lib/|g" coverage/lcov.info
-          mv coverage/cobertura.xml ../../../coverage/prompting_client_ui.xml
           mv coverage/lcov.info ../../../coverage/prompting_client_ui.info
           popd
 

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -31,17 +31,17 @@ jobs:
       - run: melos coverage
       - run: melos build
       - run: |
-          mkdir .coverage
+          mkdir coverage
           pushd flutter/packages/prompting_client
           cobertura convert
           sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
-          mv coverage/cobertura.xml ../../../.coverage/prompting_client.xml
+          mv coverage/cobertura.xml ../../../coverage/prompting_client.xml
           popd
 
           pushd flutter/apps/prompting_client_ui
           cobertura convert
           sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
-          mv coverage/cobertura.xml ../../../.coverage/prompting_client_ui.xml
+          mv coverage/cobertura.xml ../../../coverage/prompting_client_ui.xml
           popd
 
       - name: Run TICS analysis

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -35,13 +35,19 @@ jobs:
           pushd flutter/packages/prompting_client
           cobertura convert
           sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
+          sed -i "s|lib/|$(pwd)/lib/|g" coverage/cobertura.xml
+          sed -i "s|lib/|$(pwd)/lib/|g" coverage/lcov.info
           mv coverage/cobertura.xml ../../../coverage/prompting_client.xml
+          mv coverage/lcov.info ../../../coverage/prompting_client.info
           popd
 
           pushd flutter/apps/prompting_client_ui
           cobertura convert
           sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
+          sed -i "s|lib/|$(pwd)/lib/|g" coverage/cobertura.xml
+          sed -i "s|lib/|$(pwd)/lib/|g" coverage/lcov.info
           mv coverage/cobertura.xml ../../../coverage/prompting_client_ui.xml
+          mv coverage/lcov.info ../../../coverage/prompting_client_ui.info
           popd
 
       - name: Run TICS analysis


### PR DESCRIPTION
I've asked the tiobe team to change the coverage directory to `coverage` for consistency with our other repositories.
I've also removed the cobertura XML conversion for Dart, as TiCS seems to specifically look for Flutter's lcov output.

UDENG-5819