### PR TITLE
chore: include icon in snapcraft.yaml metadata

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,7 @@ issues: https://github.com/canonical/prompting-client/issues
 license: GPL-3.0
 grade: stable
 confinement: strict
+icon: snap/gui/prompting-client.png
 
 apps:
   scripted:


### PR DESCRIPTION
With the icon defined in snapcraft.yaml, it can be served over the `/v2/icons` API, and it will automatically update the snapcraft.io listing if the icon in the snap ever changes. You may need to change the "Update metadata on release" toggle in the snap settings, if this is something you want to update automatically from the snap. Since there are multiple snap tracks `latest`, `1`, it might be worth leaving the store listing manually controlled.