### PR TITLE
feat: implement GNOME Shell permission prompting functionality

### DIFF
--- a/flutter/apps/prompting_client_ui/integration_test/apparmor_prompt_test.dart
+++ b/flutter/apps/prompting_client_ui/integration_test/apparmor_prompt_test.dart
@@ -15,7 +15,7 @@ void main() {
   YaruTestWindow.ensureInitialized();
 
   testWidgets('UI dry-run', (tester) async {
-    await app.main(['firefox', '123', '--dry-run']);
+    await app.main(['--cgroup=123', '--dry-run']);
     await tester.pumpAndSettle();
 
     final fakeApparmorPromptingClient =

--- a/flutter/apps/prompting_client_ui/lib/main.dart
+++ b/flutter/apps/prompting_client_ui/lib/main.dart
@@ -32,6 +32,14 @@ Future<void> main(List<String> args) async {
       'test-prompt',
       help: 'Path to a JSON file containing the test prompt',
       defaultsTo: 'test/test_prompts/test_home_prompt_details.json',
+    )
+    ..addOption(
+      'snap',
+      help: 'Snap name',
+    )
+    ..addOption(
+      'app-pid',
+      help: 'Application PID',
     );
 
   final ArgResults argResults;
@@ -40,6 +48,14 @@ Future<void> main(List<String> args) async {
   } on FormatException catch (_) {
     stdout.writeln(parser.usage);
     exit(2);
+  }
+
+  // Log parsed arguments for debugging
+  if (argResults['snap'] != null) {
+    log.debug('Snap name: ${argResults['snap']}');
+  }
+  if (argResults['app-pid'] != null) {
+    log.debug('App PID: ${argResults['app-pid']}');
   }
 
   if (argResults.flag('dry-run')) {

--- a/flutter/apps/prompting_client_ui/lib/main.dart
+++ b/flutter/apps/prompting_client_ui/lib/main.dart
@@ -40,6 +40,10 @@ Future<void> main(List<String> args) async {
     ..addOption(
       'app-pid',
       help: 'Application PID',
+    )
+    ..addOption(
+      'cgroup',
+      help: 'Application cgroup',
     );
 
   final ArgResults argResults;
@@ -57,8 +61,12 @@ Future<void> main(List<String> args) async {
   if (argResults['app-pid'] != null) {
     log.debug('App PID: ${argResults['app-pid']}');
   }
+  if (argResults['cgroup'] != null) {
+    log.debug('Cgroup: ${argResults['cgroup']}');
+  }
 
   if (argResults.flag('dry-run')) {
+    log.info('Running in dry-run mode');
     final fileName = argResults['test-prompt'] as String;
     if (!File(fileName).existsSync()) {
       log.error('Test prompt file $fileName does not exist');
@@ -82,8 +90,13 @@ Future<void> main(List<String> args) async {
   }
 
   final completer = Completer();
+  final cgroup = argResults['cgroup'] as String?;
+  if (cgroup == null) {
+    log.error('Cgroup argument is required');
+    exit(1);
+  }
   final currentPromptStream =
-      getService<PromptingClient>().getCurrentPrompt(argResults.arguments[2]);
+      getService<PromptingClient>().getCurrentPrompt(cgroup);
   currentPromptStream.listen(
     (promptDetails) {
       registerServiceInstance<PromptDetails>(promptDetails);

--- a/flutter/apps/prompting_client_ui/linux/my_application.cc
+++ b/flutter/apps/prompting_client_ui/linux/my_application.cc
@@ -125,6 +125,7 @@ static gboolean my_application_local_command_line(GApplication* application, gch
 
   g_autoptr(GOptionContext) context = g_option_context_new(NULL);
   g_option_context_add_main_entries(context, entries, NULL);
+  g_option_context_set_ignore_unknown_options(context, TRUE);
 
   // Parse the copied arguments (this will mutate args_copy)
   if (!g_option_context_parse_strv(context, &args_copy, NULL)) {

--- a/flutter/apps/prompting_client_ui/linux/my_application.cc
+++ b/flutter/apps/prompting_client_ui/linux/my_application.cc
@@ -1,7 +1,9 @@
 #include "my_application.h"
 
+#include <gdk/gdk.h>
 #include <glib.h>
 #include <flutter_linux/flutter_linux.h>
+#include <gtk/gtk.h>
 #include <unistd.h>
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
@@ -125,6 +127,14 @@ static void my_application_activate(GApplication* application) {
 
   gtk_widget_show(GTK_WIDGET(window));
   gtk_widget_show(GTK_WIDGET(view));
+
+  GdkWindow* gdk_window = gtk_widget_get_window(GTK_WIDGET(window));
+  if (gdk_window == NULL) {
+    g_warning("Failed to get gdk_window for setting skip flags.");
+  } else {
+    gdk_window_set_skip_taskbar_hint(gdk_window, TRUE);
+    gdk_window_set_skip_pager_hint(gdk_window, TRUE);
+  }
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }

--- a/flutter/apps/prompting_client_ui/linux/my_application.cc
+++ b/flutter/apps/prompting_client_ui/linux/my_application.cc
@@ -20,8 +20,10 @@ G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 
 // Signal the Shell about a permission prompting is in progress.
 void signal_prompting_to_gnome_shell(char *snap_name, guint64 app_id) {
+
   // Ensure we are running in the ubuntu session which should have our extension.
-  if (!g_str_equal(g_environ_getenv(g_get_environ(), "GNOME_SHELL_SESSION_MODE"), "ubuntu")) {
+  const char* session_mode = g_environ_getenv(g_get_environ(), "GNOME_SHELL_SESSION_MODE");
+  if (session_mode == NULL || !g_str_equal(session_mode, "ubuntu")) {
     return;
   }
 

--- a/flutter/apps/prompting_client_ui/linux/my_application.cc
+++ b/flutter/apps/prompting_client_ui/linux/my_application.cc
@@ -21,12 +21,6 @@ G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 // Signal the Shell about a permission prompting is in progress.
 void signal_prompting_to_gnome_shell(char *snap_name, guint64 app_id) {
 
-  // Ensure we are running in the ubuntu session which should have our extension.
-  const char* session_mode = g_environ_getenv(g_get_environ(), "GNOME_SHELL_SESSION_MODE");
-  if (session_mode == NULL || !g_str_equal(session_mode, "ubuntu")) {
-    return;
-  }
-
   // If snap_name or app_id is not set, we cannot signal the GNOME Shell.
   if (snap_name == NULL || app_id == 0) {
     g_warning("Failed to extract snap name or app ID from the arguments to signal it to GNOME Shell");
@@ -107,7 +101,7 @@ static void my_application_activate(GApplication* application) {
   guint64 app_id = 0;
   for (uint i = 0; self->dart_entrypoint_arguments[i] != NULL; i++) {
     char *arg = self->dart_entrypoint_arguments[i];
-    if (g_str_has_prefix(arg, "-")) {
+    if (*arg == '-') {
       continue;
     }
 
@@ -130,15 +124,8 @@ static void my_application_activate(GApplication* application) {
   gtk_widget_show(GTK_WIDGET(window));
   gtk_widget_show(GTK_WIDGET(view));
 
-  GdkWindow* gdk_window = gtk_widget_get_window(GTK_WIDGET(window));
-  if (gdk_window == NULL) {
-    g_warning("Failed to get gdk_window for setting skip flags.");
-  } else {
-    gdk_window_set_skip_taskbar_hint(gdk_window, TRUE);
-    gdk_window_set_skip_pager_hint(gdk_window, TRUE);
-  }
-
-  gtk_widget_grab_focus(GTK_WIDGET(view));
+  gtk_window_set_skip_taskbar_hint(window, TRUE);
+  gtk_window_set_skip_pager_hint(window, TRUE);
 }
 
 // Implements GApplication::local_command_line.

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -862,7 +862,7 @@ mod tests {
         type Handle = TestDialogHandle;
         fn spawn(&mut self, args: &[&str]) -> Result<TestDialogHandle> {
             debug!("spawning test ui");
-            let cgroup: Cgroup = (*args.get(2).expect("a pid")).into();
+            let cgroup: Cgroup = (*args.get(5).expect("a cgroup")).into();
             let reply = self
                 .replies
                 .get_mut(&cgroup)

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -319,6 +319,7 @@ where
         Ok(())
     }
 
+<<<<<<< HEAD
     async fn wait_for_ui_reply(&mut self, cgroup: &Cgroup) -> Result<()> {
         debug!("waiting for ui reply");
         let exit_code = self
@@ -500,8 +501,11 @@ where
 
         debug!("spawning UI");
         let dialog_process = self.ui.spawn(&[
+            "--snap",
             enriched_prompt.prompt.snap(),
+            "--app-id",
             &enriched_prompt.prompt.pid().to_string(),
+            "--cgroup",
             &enriched_prompt.prompt.cgroup().0,
         ])?;
         self.dialog_processes.insert(cgroup.clone(), dialog_process);

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -502,7 +502,7 @@ where
         let dialog_process = self.ui.spawn(&[
             "--snap",
             enriched_prompt.prompt.snap(),
-            "--app-id",
+            "--app-pid",
             &enriched_prompt.prompt.pid().to_string(),
             "--cgroup",
             &enriched_prompt.prompt.cgroup().0,

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -319,7 +319,6 @@ where
         Ok(())
     }
 
-<<<<<<< HEAD
     async fn wait_for_ui_reply(&mut self, cgroup: &Cgroup) -> Result<()> {
         debug!("waiting for ui reply");
         let exit_code = self

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,7 @@ apps:
       - audio-playback
       - audio-record
       - snap-interfaces-requests-control
+      - gnome-shell-permission-prompting
 
   echo:
     command: bin/prompting-client-echo
@@ -51,6 +52,10 @@ apps:
 plugs:
   snap-interfaces-requests-control:
     handler-service: daemon
+  gnome-shell-permission-prompting:
+    interface: dbus
+    bus: session
+    name: com.canonical.Shell.PermissionPrompting
 
 parts:
   fvm:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,6 @@ apps:
       - audio-playback
       - audio-record
       - snap-interfaces-requests-control
-      - gnome-shell-permission-prompting
 
   echo:
     command: bin/prompting-client-echo
@@ -52,10 +51,6 @@ apps:
 plugs:
   snap-interfaces-requests-control:
     handler-service: daemon
-  gnome-shell-permission-prompting:
-    interface: dbus
-    bus: session
-    name: com.canonical.Shell.PermissionPrompting
 
 parts:
   fvm:


### PR DESCRIPTION
Added a dbus call to `com.canonical.Shell.PermissionPrompting`  in `my_application.cc` with the `snap_name` and `app_pid`, which are now expected as command line arguments to the Flutter application when launched from the `prompting_client`. 

This call is preformed before `gtk_widget_show` is called.

UDENG-7321