### PR TITLE
fix(deps): deb `protobuf-compiler` instead of snap `protobuf`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,8 +79,8 @@ parts:
     build-packages:
       - libssl-dev
       - pkg-config
-    build-snaps:
-      - protobuf
+      - protobuf-compiler      
+      - libprotobuf-dev
 
   prompting-client-ui:
     after: [fvm]


### PR DESCRIPTION
Snap [protobuf](https://snapcraft.io/protobuf) package is outdated and seems to be [unmaintained](https://github.com/stub42/protobuf-snap/issues/5)