### PR TITLE
feat: prompt cancellation

### DIFF
--- a/flutter/apps/prompting_client_ui/integration_test/apparmor_prompt_test.dart
+++ b/flutter/apps/prompting_client_ui/integration_test/apparmor_prompt_test.dart
@@ -11,7 +11,6 @@ import 'package:yaru_test/yaru_test.dart';
 import '../test/test_utils.dart';
 
 void main() {
-  tearDown(resetAllServices);
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   YaruTestWindow.ensureInitialized();
 

--- a/flutter/apps/prompting_client_ui/lib/fake_prompting_client.dart
+++ b/flutter/apps/prompting_client_ui/lib/fake_prompting_client.dart
@@ -21,7 +21,7 @@ class FakeApparmorPromptingClient implements PromptingClient {
   void Function(PromptReply reply)? onReply;
 
   @override
-  Future<PromptDetails> getCurrentPrompt() async => currentPrompt;
+  Stream<PromptDetails> getCurrentPrompt() => Stream.value(currentPrompt);
 
   @override
   Future<PromptReplyResponse> replyToPrompt(PromptReply reply) async {

--- a/flutter/apps/prompting_client_ui/lib/fake_prompting_client.dart
+++ b/flutter/apps/prompting_client_ui/lib/fake_prompting_client.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -8,7 +9,11 @@ import 'package:ubuntu_logger/ubuntu_logger.dart';
 final _log = Logger('fake_prompting_client');
 
 class FakeApparmorPromptingClient implements PromptingClient {
-  FakeApparmorPromptingClient({required this.currentPrompt});
+  FakeApparmorPromptingClient({required this.currentPrompt}) {
+    _streamController = StreamController.broadcast(
+      onListen: () => _streamController.add(currentPrompt),
+    );
+  }
   factory FakeApparmorPromptingClient.fromFile(String path) {
     final currentPrompt = PromptDetails.fromJson(
       jsonDecode(File(path).readAsStringSync()) as Map<String, dynamic>,
@@ -16,12 +21,15 @@ class FakeApparmorPromptingClient implements PromptingClient {
     return FakeApparmorPromptingClient(currentPrompt: currentPrompt);
   }
   final PromptDetails currentPrompt;
+  late final StreamController<PromptDetails> _streamController;
+
+  void dispose() => _streamController.close();
 
   @visibleForTesting
   void Function(PromptReply reply)? onReply;
 
   @override
-  Stream<PromptDetails> getCurrentPrompt() => Stream.value(currentPrompt);
+  Stream<PromptDetails> getCurrentPrompt() => _streamController.stream;
 
   @override
   Future<PromptReplyResponse> replyToPrompt(PromptReply reply) async {

--- a/flutter/apps/prompting_client_ui/lib/main.dart
+++ b/flutter/apps/prompting_client_ui/lib/main.dart
@@ -76,6 +76,10 @@ Future<void> main(List<String> args) async {
       log.info('stream closed - exiting');
       exit(3);
     },
+    onError: (e) {
+      log.error('Caught grpc error $e - exiting');
+      exit(4);
+    },
   );
   await completer.future;
 

--- a/flutter/apps/prompting_client_ui/lib/main.dart
+++ b/flutter/apps/prompting_client_ui/lib/main.dart
@@ -50,6 +50,7 @@ Future<void> main(List<String> args) async {
     }
     registerService<PromptingClient>(
       () => FakeApparmorPromptingClient.fromFile(fileName),
+      dispose: (service) => (service as FakeApparmorPromptingClient).dispose(),
     );
   } else {
     final socketPath = Platform.environment[envVarSocketPath];

--- a/flutter/apps/prompting_client_ui/lib/main.dart
+++ b/flutter/apps/prompting_client_ui/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -63,8 +64,19 @@ Future<void> main(List<String> args) async {
     );
   }
 
-  final currentPrompt = await getService<PromptingClient>().getCurrentPrompt();
-  registerServiceInstance<PromptDetails>(currentPrompt);
+  final completer = Completer();
+  final currentPromptStream = getService<PromptingClient>().getCurrentPrompt();
+  currentPromptStream.listen(
+    (promptDetails) {
+      registerServiceInstance<PromptDetails>(promptDetails);
+      completer.complete();
+    },
+    onDone: () {
+      log.info('stream closed - exiting');
+      exit(3);
+    },
+  );
+  await completer.future;
 
   await initDefaultLocale();
 

--- a/flutter/apps/prompting_client_ui/pubspec.lock
+++ b/flutter/apps/prompting_client_ui/pubspec.lock
@@ -735,10 +735,10 @@ packages:
     dependency: transitive
     description:
       name: protobuf
-      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
+      sha256: "6153efcc92a06910918f3db8231fd2cf828ac81e50ebd87adc8f8a8cb3caff0e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.1.1"
   pub_semver:
     dependency: transitive
     description:

--- a/flutter/apps/prompting_client_ui/test/test_utils.dart
+++ b/flutter/apps/prompting_client_ui/test/test_utils.dart
@@ -95,7 +95,8 @@ PromptingClient registerMockAppArmorPromptingClient({
   provideDummy<PromptDetails>(mockPromptDetailsHome());
   provideDummy<PromptReplyResponse>(PromptReplyResponse.unknown(message: ''));
   final client = MockPromptingClient();
-  when(client.getCurrentPrompt()).thenAnswer((_) async => promptDetails);
+  when(client.getCurrentPrompt())
+      .thenAnswer((_) => Stream.value(promptDetails));
   when(client.replyToPrompt(any)).thenAnswer(
     (_) async => replyResponse ?? PromptReplyResponse.unknown(message: ''),
   );

--- a/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pb.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pb.dart
@@ -1,13 +1,14 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: apparmor-prompting.proto
-//
-// @dart = 2.12
+// Generated from apparmor-prompting.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:core' as $core;
 
@@ -16,12 +17,11 @@ import 'package:protobuf/protobuf.dart' as $pb;
 import 'apparmor-prompting.pbenum.dart';
 import 'google/protobuf/empty.pb.dart' as $0;
 
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
+
 export 'apparmor-prompting.pbenum.dart';
 
-enum PromptReply_PromptReply {
-  homePromptReply, 
-  notSet
-}
+enum PromptReply_PromptReply { homePromptReply, notSet }
 
 class PromptReply extends $pb.GeneratedMessage {
   factory PromptReply({
@@ -30,97 +30,106 @@ class PromptReply extends $pb.GeneratedMessage {
     Lifespan? lifespan,
     HomePromptReply? homePromptReply,
   }) {
-    final $result = create();
-    if (promptId != null) {
-      $result.promptId = promptId;
-    }
-    if (action != null) {
-      $result.action = action;
-    }
-    if (lifespan != null) {
-      $result.lifespan = lifespan;
-    }
-    if (homePromptReply != null) {
-      $result.homePromptReply = homePromptReply;
-    }
-    return $result;
+    final result = create();
+    if (promptId != null) result.promptId = promptId;
+    if (action != null) result.action = action;
+    if (lifespan != null) result.lifespan = lifespan;
+    if (homePromptReply != null) result.homePromptReply = homePromptReply;
+    return result;
   }
-  PromptReply._() : super();
-  factory PromptReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PromptReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static const $core.Map<$core.int, PromptReply_PromptReply> _PromptReply_PromptReplyByTag = {
-    4 : PromptReply_PromptReply.homePromptReply,
-    0 : PromptReply_PromptReply.notSet
+  PromptReply._();
+
+  factory PromptReply.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PromptReply.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static const $core.Map<$core.int, PromptReply_PromptReply>
+      _PromptReply_PromptReplyByTag = {
+    4: PromptReply_PromptReply.homePromptReply,
+    0: PromptReply_PromptReply.notSet
   };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PromptReply', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PromptReply',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..oo(0, [4])
     ..aOS(1, _omitFieldNames ? '' : 'promptId')
-    ..e<Action>(2, _omitFieldNames ? '' : 'action', $pb.PbFieldType.OE, defaultOrMaker: Action.ALLOW, valueOf: Action.valueOf, enumValues: Action.values)
-    ..e<Lifespan>(3, _omitFieldNames ? '' : 'lifespan', $pb.PbFieldType.OE, defaultOrMaker: Lifespan.SINGLE, valueOf: Lifespan.valueOf, enumValues: Lifespan.values)
-    ..aOM<HomePromptReply>(4, _omitFieldNames ? '' : 'homePromptReply', subBuilder: HomePromptReply.create)
-    ..hasRequiredFields = false
-  ;
+    ..e<Action>(2, _omitFieldNames ? '' : 'action', $pb.PbFieldType.OE,
+        defaultOrMaker: Action.ALLOW,
+        valueOf: Action.valueOf,
+        enumValues: Action.values)
+    ..e<Lifespan>(3, _omitFieldNames ? '' : 'lifespan', $pb.PbFieldType.OE,
+        defaultOrMaker: Lifespan.SINGLE,
+        valueOf: Lifespan.valueOf,
+        enumValues: Lifespan.values)
+    ..aOM<HomePromptReply>(4, _omitFieldNames ? '' : 'homePromptReply',
+        subBuilder: HomePromptReply.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PromptReply clone() => PromptReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PromptReply copyWith(void Function(PromptReply) updates) => super.copyWith((message) => updates(message as PromptReply)) as PromptReply;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReply copyWith(void Function(PromptReply) updates) =>
+      super.copyWith((message) => updates(message as PromptReply))
+          as PromptReply;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static PromptReply create() => PromptReply._();
+  @$core.override
   PromptReply createEmptyInstance() => create();
   static $pb.PbList<PromptReply> createRepeated() => $pb.PbList<PromptReply>();
   @$core.pragma('dart2js:noInline')
-  static PromptReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PromptReply>(create);
+  static PromptReply getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<PromptReply>(create);
   static PromptReply? _defaultInstance;
 
-  PromptReply_PromptReply whichPromptReply() => _PromptReply_PromptReplyByTag[$_whichOneof(0)]!;
-  void clearPromptReply() => clearField($_whichOneof(0));
+  PromptReply_PromptReply whichPromptReply() =>
+      _PromptReply_PromptReplyByTag[$_whichOneof(0)]!;
+  void clearPromptReply() => $_clearField($_whichOneof(0));
 
   @$pb.TagNumber(1)
   $core.String get promptId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set promptId($core.String v) { $_setString(0, v); }
+  set promptId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPromptId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPromptId() => clearField(1);
+  void clearPromptId() => $_clearField(1);
 
   @$pb.TagNumber(2)
   Action get action => $_getN(1);
   @$pb.TagNumber(2)
-  set action(Action v) { setField(2, v); }
+  set action(Action value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasAction() => $_has(1);
   @$pb.TagNumber(2)
-  void clearAction() => clearField(2);
+  void clearAction() => $_clearField(2);
 
   @$pb.TagNumber(3)
   Lifespan get lifespan => $_getN(2);
   @$pb.TagNumber(3)
-  set lifespan(Lifespan v) { setField(3, v); }
+  set lifespan(Lifespan value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasLifespan() => $_has(2);
   @$pb.TagNumber(3)
-  void clearLifespan() => clearField(3);
+  void clearLifespan() => $_clearField(3);
 
   @$pb.TagNumber(4)
   HomePromptReply get homePromptReply => $_getN(3);
   @$pb.TagNumber(4)
-  set homePromptReply(HomePromptReply v) { setField(4, v); }
+  set homePromptReply(HomePromptReply value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasHomePromptReply() => $_has(3);
   @$pb.TagNumber(4)
-  void clearHomePromptReply() => clearField(4);
+  void clearHomePromptReply() => $_clearField(4);
   @$pb.TagNumber(4)
   HomePromptReply ensureHomePromptReply() => $_ensure(3);
 }
@@ -129,44 +138,60 @@ class PromptReplyResponse_HomeRuleConflicts extends $pb.GeneratedMessage {
   factory PromptReplyResponse_HomeRuleConflicts({
     $core.Iterable<PromptReplyResponse_HomeRuleConflict>? conflicts,
   }) {
-    final $result = create();
-    if (conflicts != null) {
-      $result.conflicts.addAll(conflicts);
-    }
-    return $result;
+    final result = create();
+    if (conflicts != null) result.conflicts.addAll(conflicts);
+    return result;
   }
-  PromptReplyResponse_HomeRuleConflicts._() : super();
-  factory PromptReplyResponse_HomeRuleConflicts.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PromptReplyResponse_HomeRuleConflicts.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PromptReplyResponse.HomeRuleConflicts', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
-    ..pc<PromptReplyResponse_HomeRuleConflict>(1, _omitFieldNames ? '' : 'conflicts', $pb.PbFieldType.PM, subBuilder: PromptReplyResponse_HomeRuleConflict.create)
-    ..hasRequiredFields = false
-  ;
+  PromptReplyResponse_HomeRuleConflicts._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_HomeRuleConflicts clone() => PromptReplyResponse_HomeRuleConflicts()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_HomeRuleConflicts copyWith(void Function(PromptReplyResponse_HomeRuleConflicts) updates) => super.copyWith((message) => updates(message as PromptReplyResponse_HomeRuleConflicts)) as PromptReplyResponse_HomeRuleConflicts;
+  factory PromptReplyResponse_HomeRuleConflicts.fromBuffer(
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PromptReplyResponse_HomeRuleConflicts.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
 
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PromptReplyResponse.HomeRuleConflicts',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
+    ..pc<PromptReplyResponse_HomeRuleConflict>(
+        1, _omitFieldNames ? '' : 'conflicts', $pb.PbFieldType.PM,
+        subBuilder: PromptReplyResponse_HomeRuleConflict.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_HomeRuleConflicts clone() =>
+      PromptReplyResponse_HomeRuleConflicts()..mergeFromMessage(this);
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_HomeRuleConflicts copyWith(
+          void Function(PromptReplyResponse_HomeRuleConflicts) updates) =>
+      super.copyWith((message) =>
+              updates(message as PromptReplyResponse_HomeRuleConflicts))
+          as PromptReplyResponse_HomeRuleConflicts;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_HomeRuleConflicts create() => PromptReplyResponse_HomeRuleConflicts._();
+  static PromptReplyResponse_HomeRuleConflicts create() =>
+      PromptReplyResponse_HomeRuleConflicts._();
+  @$core.override
   PromptReplyResponse_HomeRuleConflicts createEmptyInstance() => create();
-  static $pb.PbList<PromptReplyResponse_HomeRuleConflicts> createRepeated() => $pb.PbList<PromptReplyResponse_HomeRuleConflicts>();
+  static $pb.PbList<PromptReplyResponse_HomeRuleConflicts> createRepeated() =>
+      $pb.PbList<PromptReplyResponse_HomeRuleConflicts>();
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_HomeRuleConflicts getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PromptReplyResponse_HomeRuleConflicts>(create);
+  static PromptReplyResponse_HomeRuleConflicts getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
+          PromptReplyResponse_HomeRuleConflicts>(create);
   static PromptReplyResponse_HomeRuleConflicts? _defaultInstance;
 
   @$pb.TagNumber(1)
-  $core.List<PromptReplyResponse_HomeRuleConflict> get conflicts => $_getList(0);
+  $pb.PbList<PromptReplyResponse_HomeRuleConflict> get conflicts =>
+      $_getList(0);
 }
 
 class PromptReplyResponse_HomeRuleConflict extends $pb.GeneratedMessage {
@@ -175,76 +200,89 @@ class PromptReplyResponse_HomeRuleConflict extends $pb.GeneratedMessage {
     $core.String? variant,
     $core.String? conflictingId,
   }) {
-    final $result = create();
-    if (permission != null) {
-      $result.permission = permission;
-    }
-    if (variant != null) {
-      $result.variant = variant;
-    }
-    if (conflictingId != null) {
-      $result.conflictingId = conflictingId;
-    }
-    return $result;
+    final result = create();
+    if (permission != null) result.permission = permission;
+    if (variant != null) result.variant = variant;
+    if (conflictingId != null) result.conflictingId = conflictingId;
+    return result;
   }
-  PromptReplyResponse_HomeRuleConflict._() : super();
-  factory PromptReplyResponse_HomeRuleConflict.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PromptReplyResponse_HomeRuleConflict.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PromptReplyResponse.HomeRuleConflict', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
-    ..e<HomePermission>(1, _omitFieldNames ? '' : 'permission', $pb.PbFieldType.OE, defaultOrMaker: HomePermission.READ, valueOf: HomePermission.valueOf, enumValues: HomePermission.values)
+  PromptReplyResponse_HomeRuleConflict._();
+
+  factory PromptReplyResponse_HomeRuleConflict.fromBuffer(
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PromptReplyResponse_HomeRuleConflict.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PromptReplyResponse.HomeRuleConflict',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
+    ..e<HomePermission>(
+        1, _omitFieldNames ? '' : 'permission', $pb.PbFieldType.OE,
+        defaultOrMaker: HomePermission.READ,
+        valueOf: HomePermission.valueOf,
+        enumValues: HomePermission.values)
     ..aOS(2, _omitFieldNames ? '' : 'variant')
     ..aOS(3, _omitFieldNames ? '' : 'conflictingId')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_HomeRuleConflict clone() => PromptReplyResponse_HomeRuleConflict()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_HomeRuleConflict copyWith(void Function(PromptReplyResponse_HomeRuleConflict) updates) => super.copyWith((message) => updates(message as PromptReplyResponse_HomeRuleConflict)) as PromptReplyResponse_HomeRuleConflict;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_HomeRuleConflict clone() =>
+      PromptReplyResponse_HomeRuleConflict()..mergeFromMessage(this);
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_HomeRuleConflict copyWith(
+          void Function(PromptReplyResponse_HomeRuleConflict) updates) =>
+      super.copyWith((message) =>
+              updates(message as PromptReplyResponse_HomeRuleConflict))
+          as PromptReplyResponse_HomeRuleConflict;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_HomeRuleConflict create() => PromptReplyResponse_HomeRuleConflict._();
+  static PromptReplyResponse_HomeRuleConflict create() =>
+      PromptReplyResponse_HomeRuleConflict._();
+  @$core.override
   PromptReplyResponse_HomeRuleConflict createEmptyInstance() => create();
-  static $pb.PbList<PromptReplyResponse_HomeRuleConflict> createRepeated() => $pb.PbList<PromptReplyResponse_HomeRuleConflict>();
+  static $pb.PbList<PromptReplyResponse_HomeRuleConflict> createRepeated() =>
+      $pb.PbList<PromptReplyResponse_HomeRuleConflict>();
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_HomeRuleConflict getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PromptReplyResponse_HomeRuleConflict>(create);
+  static PromptReplyResponse_HomeRuleConflict getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
+          PromptReplyResponse_HomeRuleConflict>(create);
   static PromptReplyResponse_HomeRuleConflict? _defaultInstance;
 
   @$pb.TagNumber(1)
   HomePermission get permission => $_getN(0);
   @$pb.TagNumber(1)
-  set permission(HomePermission v) { setField(1, v); }
+  set permission(HomePermission value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasPermission() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPermission() => clearField(1);
+  void clearPermission() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $core.String get variant => $_getSZ(1);
   @$pb.TagNumber(2)
-  set variant($core.String v) { $_setString(1, v); }
+  set variant($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasVariant() => $_has(1);
   @$pb.TagNumber(2)
-  void clearVariant() => clearField(2);
+  void clearVariant() => $_clearField(2);
 
   @$pb.TagNumber(3)
   $core.String get conflictingId => $_getSZ(2);
   @$pb.TagNumber(3)
-  set conflictingId($core.String v) { $_setString(2, v); }
+  set conflictingId($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasConflictingId() => $_has(2);
   @$pb.TagNumber(3)
-  void clearConflictingId() => clearField(3);
+  void clearConflictingId() => $_clearField(3);
 }
 
 class PromptReplyResponse_InvalidHomePermissions extends $pb.GeneratedMessage {
@@ -252,51 +290,71 @@ class PromptReplyResponse_InvalidHomePermissions extends $pb.GeneratedMessage {
     $core.Iterable<HomePermission>? requested,
     $core.Iterable<HomePermission>? replied,
   }) {
-    final $result = create();
-    if (requested != null) {
-      $result.requested.addAll(requested);
-    }
-    if (replied != null) {
-      $result.replied.addAll(replied);
-    }
-    return $result;
+    final result = create();
+    if (requested != null) result.requested.addAll(requested);
+    if (replied != null) result.replied.addAll(replied);
+    return result;
   }
-  PromptReplyResponse_InvalidHomePermissions._() : super();
-  factory PromptReplyResponse_InvalidHomePermissions.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PromptReplyResponse_InvalidHomePermissions.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PromptReplyResponse.InvalidHomePermissions', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
-    ..pc<HomePermission>(1, _omitFieldNames ? '' : 'requested', $pb.PbFieldType.KE, valueOf: HomePermission.valueOf, enumValues: HomePermission.values, defaultEnumValue: HomePermission.READ)
-    ..pc<HomePermission>(2, _omitFieldNames ? '' : 'replied', $pb.PbFieldType.KE, valueOf: HomePermission.valueOf, enumValues: HomePermission.values, defaultEnumValue: HomePermission.READ)
-    ..hasRequiredFields = false
-  ;
+  PromptReplyResponse_InvalidHomePermissions._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_InvalidHomePermissions clone() => PromptReplyResponse_InvalidHomePermissions()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_InvalidHomePermissions copyWith(void Function(PromptReplyResponse_InvalidHomePermissions) updates) => super.copyWith((message) => updates(message as PromptReplyResponse_InvalidHomePermissions)) as PromptReplyResponse_InvalidHomePermissions;
+  factory PromptReplyResponse_InvalidHomePermissions.fromBuffer(
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PromptReplyResponse_InvalidHomePermissions.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
 
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PromptReplyResponse.InvalidHomePermissions',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
+    ..pc<HomePermission>(
+        1, _omitFieldNames ? '' : 'requested', $pb.PbFieldType.KE,
+        valueOf: HomePermission.valueOf,
+        enumValues: HomePermission.values,
+        defaultEnumValue: HomePermission.READ)
+    ..pc<HomePermission>(
+        2, _omitFieldNames ? '' : 'replied', $pb.PbFieldType.KE,
+        valueOf: HomePermission.valueOf,
+        enumValues: HomePermission.values,
+        defaultEnumValue: HomePermission.READ)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_InvalidHomePermissions clone() =>
+      PromptReplyResponse_InvalidHomePermissions()..mergeFromMessage(this);
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_InvalidHomePermissions copyWith(
+          void Function(PromptReplyResponse_InvalidHomePermissions) updates) =>
+      super.copyWith((message) =>
+              updates(message as PromptReplyResponse_InvalidHomePermissions))
+          as PromptReplyResponse_InvalidHomePermissions;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_InvalidHomePermissions create() => PromptReplyResponse_InvalidHomePermissions._();
+  static PromptReplyResponse_InvalidHomePermissions create() =>
+      PromptReplyResponse_InvalidHomePermissions._();
+  @$core.override
   PromptReplyResponse_InvalidHomePermissions createEmptyInstance() => create();
-  static $pb.PbList<PromptReplyResponse_InvalidHomePermissions> createRepeated() => $pb.PbList<PromptReplyResponse_InvalidHomePermissions>();
+  static $pb.PbList<PromptReplyResponse_InvalidHomePermissions>
+      createRepeated() =>
+          $pb.PbList<PromptReplyResponse_InvalidHomePermissions>();
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_InvalidHomePermissions getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PromptReplyResponse_InvalidHomePermissions>(create);
+  static PromptReplyResponse_InvalidHomePermissions getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
+          PromptReplyResponse_InvalidHomePermissions>(create);
   static PromptReplyResponse_InvalidHomePermissions? _defaultInstance;
 
   @$pb.TagNumber(1)
-  $core.List<HomePermission> get requested => $_getList(0);
+  $pb.PbList<HomePermission> get requested => $_getList(0);
 
   @$pb.TagNumber(2)
-  $core.List<HomePermission> get replied => $_getList(1);
+  $pb.PbList<HomePermission> get replied => $_getList(1);
 }
 
 class PromptReplyResponse_InvalidPathPattern extends $pb.GeneratedMessage {
@@ -304,63 +362,74 @@ class PromptReplyResponse_InvalidPathPattern extends $pb.GeneratedMessage {
     $core.String? requested,
     $core.String? replied,
   }) {
-    final $result = create();
-    if (requested != null) {
-      $result.requested = requested;
-    }
-    if (replied != null) {
-      $result.replied = replied;
-    }
-    return $result;
+    final result = create();
+    if (requested != null) result.requested = requested;
+    if (replied != null) result.replied = replied;
+    return result;
   }
-  PromptReplyResponse_InvalidPathPattern._() : super();
-  factory PromptReplyResponse_InvalidPathPattern.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PromptReplyResponse_InvalidPathPattern.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PromptReplyResponse.InvalidPathPattern', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  PromptReplyResponse_InvalidPathPattern._();
+
+  factory PromptReplyResponse_InvalidPathPattern.fromBuffer(
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PromptReplyResponse_InvalidPathPattern.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PromptReplyResponse.InvalidPathPattern',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'requested')
     ..aOS(2, _omitFieldNames ? '' : 'replied')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_InvalidPathPattern clone() => PromptReplyResponse_InvalidPathPattern()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_InvalidPathPattern copyWith(void Function(PromptReplyResponse_InvalidPathPattern) updates) => super.copyWith((message) => updates(message as PromptReplyResponse_InvalidPathPattern)) as PromptReplyResponse_InvalidPathPattern;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_InvalidPathPattern clone() =>
+      PromptReplyResponse_InvalidPathPattern()..mergeFromMessage(this);
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_InvalidPathPattern copyWith(
+          void Function(PromptReplyResponse_InvalidPathPattern) updates) =>
+      super.copyWith((message) =>
+              updates(message as PromptReplyResponse_InvalidPathPattern))
+          as PromptReplyResponse_InvalidPathPattern;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_InvalidPathPattern create() => PromptReplyResponse_InvalidPathPattern._();
+  static PromptReplyResponse_InvalidPathPattern create() =>
+      PromptReplyResponse_InvalidPathPattern._();
+  @$core.override
   PromptReplyResponse_InvalidPathPattern createEmptyInstance() => create();
-  static $pb.PbList<PromptReplyResponse_InvalidPathPattern> createRepeated() => $pb.PbList<PromptReplyResponse_InvalidPathPattern>();
+  static $pb.PbList<PromptReplyResponse_InvalidPathPattern> createRepeated() =>
+      $pb.PbList<PromptReplyResponse_InvalidPathPattern>();
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_InvalidPathPattern getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PromptReplyResponse_InvalidPathPattern>(create);
+  static PromptReplyResponse_InvalidPathPattern getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
+          PromptReplyResponse_InvalidPathPattern>(create);
   static PromptReplyResponse_InvalidPathPattern? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get requested => $_getSZ(0);
   @$pb.TagNumber(1)
-  set requested($core.String v) { $_setString(0, v); }
+  set requested($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasRequested() => $_has(0);
   @$pb.TagNumber(1)
-  void clearRequested() => clearField(1);
+  void clearRequested() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $core.String get replied => $_getSZ(1);
   @$pb.TagNumber(2)
-  set replied($core.String v) { $_setString(1, v); }
+  set replied($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasReplied() => $_has(1);
   @$pb.TagNumber(2)
-  void clearReplied() => clearField(2);
+  void clearReplied() => $_clearField(2);
 }
 
 class PromptReplyResponse_ParseError extends $pb.GeneratedMessage {
@@ -368,63 +437,72 @@ class PromptReplyResponse_ParseError extends $pb.GeneratedMessage {
     $core.String? field_1,
     $core.String? value,
   }) {
-    final $result = create();
-    if (field_1 != null) {
-      $result.field_1 = field_1;
-    }
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
+    final result = create();
+    if (field_1 != null) result.field_1 = field_1;
+    if (value != null) result.value = value;
+    return result;
   }
-  PromptReplyResponse_ParseError._() : super();
-  factory PromptReplyResponse_ParseError.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PromptReplyResponse_ParseError.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PromptReplyResponse.ParseError', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  PromptReplyResponse_ParseError._();
+
+  factory PromptReplyResponse_ParseError.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PromptReplyResponse_ParseError.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PromptReplyResponse.ParseError',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'field')
     ..aOS(2, _omitFieldNames ? '' : 'value')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_ParseError clone() => PromptReplyResponse_ParseError()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_ParseError copyWith(void Function(PromptReplyResponse_ParseError) updates) => super.copyWith((message) => updates(message as PromptReplyResponse_ParseError)) as PromptReplyResponse_ParseError;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_ParseError clone() =>
+      PromptReplyResponse_ParseError()..mergeFromMessage(this);
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_ParseError copyWith(
+          void Function(PromptReplyResponse_ParseError) updates) =>
+      super.copyWith(
+              (message) => updates(message as PromptReplyResponse_ParseError))
+          as PromptReplyResponse_ParseError;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_ParseError create() => PromptReplyResponse_ParseError._();
+  static PromptReplyResponse_ParseError create() =>
+      PromptReplyResponse_ParseError._();
+  @$core.override
   PromptReplyResponse_ParseError createEmptyInstance() => create();
-  static $pb.PbList<PromptReplyResponse_ParseError> createRepeated() => $pb.PbList<PromptReplyResponse_ParseError>();
+  static $pb.PbList<PromptReplyResponse_ParseError> createRepeated() =>
+      $pb.PbList<PromptReplyResponse_ParseError>();
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_ParseError getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PromptReplyResponse_ParseError>(create);
+  static PromptReplyResponse_ParseError getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<PromptReplyResponse_ParseError>(create);
   static PromptReplyResponse_ParseError? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get field_1 => $_getSZ(0);
   @$pb.TagNumber(1)
-  set field_1($core.String v) { $_setString(0, v); }
+  set field_1($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasField_1() => $_has(0);
   @$pb.TagNumber(1)
-  void clearField_1() => clearField(1);
+  void clearField_1() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $core.String get value => $_getSZ(1);
   @$pb.TagNumber(2)
-  set value($core.String v) { $_setString(1, v); }
+  set value($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasValue() => $_has(1);
   @$pb.TagNumber(2)
-  void clearValue() => clearField(2);
+  void clearValue() => $_clearField(2);
 }
 
 class PromptReplyResponse_UnsupportedValue extends $pb.GeneratedMessage {
@@ -433,76 +511,85 @@ class PromptReplyResponse_UnsupportedValue extends $pb.GeneratedMessage {
     $core.Iterable<$core.String>? supported,
     $core.Iterable<$core.String>? provided,
   }) {
-    final $result = create();
-    if (field_1 != null) {
-      $result.field_1 = field_1;
-    }
-    if (supported != null) {
-      $result.supported.addAll(supported);
-    }
-    if (provided != null) {
-      $result.provided.addAll(provided);
-    }
-    return $result;
+    final result = create();
+    if (field_1 != null) result.field_1 = field_1;
+    if (supported != null) result.supported.addAll(supported);
+    if (provided != null) result.provided.addAll(provided);
+    return result;
   }
-  PromptReplyResponse_UnsupportedValue._() : super();
-  factory PromptReplyResponse_UnsupportedValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PromptReplyResponse_UnsupportedValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PromptReplyResponse.UnsupportedValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  PromptReplyResponse_UnsupportedValue._();
+
+  factory PromptReplyResponse_UnsupportedValue.fromBuffer(
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PromptReplyResponse_UnsupportedValue.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PromptReplyResponse.UnsupportedValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'field')
     ..pPS(2, _omitFieldNames ? '' : 'supported')
     ..pPS(3, _omitFieldNames ? '' : 'provided')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_UnsupportedValue clone() => PromptReplyResponse_UnsupportedValue()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse_UnsupportedValue copyWith(void Function(PromptReplyResponse_UnsupportedValue) updates) => super.copyWith((message) => updates(message as PromptReplyResponse_UnsupportedValue)) as PromptReplyResponse_UnsupportedValue;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_UnsupportedValue clone() =>
+      PromptReplyResponse_UnsupportedValue()..mergeFromMessage(this);
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse_UnsupportedValue copyWith(
+          void Function(PromptReplyResponse_UnsupportedValue) updates) =>
+      super.copyWith((message) =>
+              updates(message as PromptReplyResponse_UnsupportedValue))
+          as PromptReplyResponse_UnsupportedValue;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_UnsupportedValue create() => PromptReplyResponse_UnsupportedValue._();
+  static PromptReplyResponse_UnsupportedValue create() =>
+      PromptReplyResponse_UnsupportedValue._();
+  @$core.override
   PromptReplyResponse_UnsupportedValue createEmptyInstance() => create();
-  static $pb.PbList<PromptReplyResponse_UnsupportedValue> createRepeated() => $pb.PbList<PromptReplyResponse_UnsupportedValue>();
+  static $pb.PbList<PromptReplyResponse_UnsupportedValue> createRepeated() =>
+      $pb.PbList<PromptReplyResponse_UnsupportedValue>();
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse_UnsupportedValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PromptReplyResponse_UnsupportedValue>(create);
+  static PromptReplyResponse_UnsupportedValue getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
+          PromptReplyResponse_UnsupportedValue>(create);
   static PromptReplyResponse_UnsupportedValue? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get field_1 => $_getSZ(0);
   @$pb.TagNumber(1)
-  set field_1($core.String v) { $_setString(0, v); }
+  set field_1($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasField_1() => $_has(0);
   @$pb.TagNumber(1)
-  void clearField_1() => clearField(1);
+  void clearField_1() => $_clearField(1);
 
   @$pb.TagNumber(2)
-  $core.List<$core.String> get supported => $_getList(1);
+  $pb.PbList<$core.String> get supported => $_getList(1);
 
   @$pb.TagNumber(3)
-  $core.List<$core.String> get provided => $_getList(2);
+  $pb.PbList<$core.String> get provided => $_getList(2);
 }
 
 enum PromptReplyResponse_PromptReplyType {
-  success, 
-  raw, 
-  promptNotFound, 
-  ruleNotFound, 
-  ruleConflicts, 
-  invalidPermissions, 
-  invalidPathPattern, 
-  parseError, 
-  unsupportedValue, 
+  success,
+  raw,
+  promptNotFound,
+  ruleNotFound,
+  ruleConflicts,
+  invalidPermissions,
+  invalidPathPattern,
+  parseError,
+  unsupportedValue,
   notSet
 }
 
@@ -519,264 +606,287 @@ class PromptReplyResponse extends $pb.GeneratedMessage {
     PromptReplyResponse_ParseError? parseError,
     PromptReplyResponse_UnsupportedValue? unsupportedValue,
   }) {
-    final $result = create();
-    if (message != null) {
-      $result.message = message;
-    }
-    if (success != null) {
-      $result.success = success;
-    }
-    if (raw != null) {
-      $result.raw = raw;
-    }
-    if (promptNotFound != null) {
-      $result.promptNotFound = promptNotFound;
-    }
-    if (ruleNotFound != null) {
-      $result.ruleNotFound = ruleNotFound;
-    }
-    if (ruleConflicts != null) {
-      $result.ruleConflicts = ruleConflicts;
-    }
-    if (invalidPermissions != null) {
-      $result.invalidPermissions = invalidPermissions;
-    }
-    if (invalidPathPattern != null) {
-      $result.invalidPathPattern = invalidPathPattern;
-    }
-    if (parseError != null) {
-      $result.parseError = parseError;
-    }
-    if (unsupportedValue != null) {
-      $result.unsupportedValue = unsupportedValue;
-    }
-    return $result;
+    final result = create();
+    if (message != null) result.message = message;
+    if (success != null) result.success = success;
+    if (raw != null) result.raw = raw;
+    if (promptNotFound != null) result.promptNotFound = promptNotFound;
+    if (ruleNotFound != null) result.ruleNotFound = ruleNotFound;
+    if (ruleConflicts != null) result.ruleConflicts = ruleConflicts;
+    if (invalidPermissions != null)
+      result.invalidPermissions = invalidPermissions;
+    if (invalidPathPattern != null)
+      result.invalidPathPattern = invalidPathPattern;
+    if (parseError != null) result.parseError = parseError;
+    if (unsupportedValue != null) result.unsupportedValue = unsupportedValue;
+    return result;
   }
-  PromptReplyResponse._() : super();
-  factory PromptReplyResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PromptReplyResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static const $core.Map<$core.int, PromptReplyResponse_PromptReplyType> _PromptReplyResponse_PromptReplyTypeByTag = {
-    2 : PromptReplyResponse_PromptReplyType.success,
-    3 : PromptReplyResponse_PromptReplyType.raw,
-    4 : PromptReplyResponse_PromptReplyType.promptNotFound,
-    5 : PromptReplyResponse_PromptReplyType.ruleNotFound,
-    6 : PromptReplyResponse_PromptReplyType.ruleConflicts,
-    7 : PromptReplyResponse_PromptReplyType.invalidPermissions,
-    8 : PromptReplyResponse_PromptReplyType.invalidPathPattern,
-    9 : PromptReplyResponse_PromptReplyType.parseError,
-    10 : PromptReplyResponse_PromptReplyType.unsupportedValue,
-    0 : PromptReplyResponse_PromptReplyType.notSet
+  PromptReplyResponse._();
+
+  factory PromptReplyResponse.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PromptReplyResponse.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static const $core.Map<$core.int, PromptReplyResponse_PromptReplyType>
+      _PromptReplyResponse_PromptReplyTypeByTag = {
+    2: PromptReplyResponse_PromptReplyType.success,
+    3: PromptReplyResponse_PromptReplyType.raw,
+    4: PromptReplyResponse_PromptReplyType.promptNotFound,
+    5: PromptReplyResponse_PromptReplyType.ruleNotFound,
+    6: PromptReplyResponse_PromptReplyType.ruleConflicts,
+    7: PromptReplyResponse_PromptReplyType.invalidPermissions,
+    8: PromptReplyResponse_PromptReplyType.invalidPathPattern,
+    9: PromptReplyResponse_PromptReplyType.parseError,
+    10: PromptReplyResponse_PromptReplyType.unsupportedValue,
+    0: PromptReplyResponse_PromptReplyType.notSet
   };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PromptReplyResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PromptReplyResponse',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..oo(0, [2, 3, 4, 5, 6, 7, 8, 9, 10])
     ..aOS(1, _omitFieldNames ? '' : 'message')
-    ..aOM<$0.Empty>(2, _omitFieldNames ? '' : 'success', subBuilder: $0.Empty.create)
-    ..aOM<$0.Empty>(3, _omitFieldNames ? '' : 'raw', subBuilder: $0.Empty.create)
-    ..aOM<$0.Empty>(4, _omitFieldNames ? '' : 'promptNotFound', subBuilder: $0.Empty.create)
-    ..aOM<$0.Empty>(5, _omitFieldNames ? '' : 'ruleNotFound', subBuilder: $0.Empty.create)
-    ..aOM<PromptReplyResponse_HomeRuleConflicts>(6, _omitFieldNames ? '' : 'ruleConflicts', subBuilder: PromptReplyResponse_HomeRuleConflicts.create)
-    ..aOM<PromptReplyResponse_InvalidHomePermissions>(7, _omitFieldNames ? '' : 'invalidPermissions', subBuilder: PromptReplyResponse_InvalidHomePermissions.create)
-    ..aOM<PromptReplyResponse_InvalidPathPattern>(8, _omitFieldNames ? '' : 'invalidPathPattern', subBuilder: PromptReplyResponse_InvalidPathPattern.create)
-    ..aOM<PromptReplyResponse_ParseError>(9, _omitFieldNames ? '' : 'parseError', subBuilder: PromptReplyResponse_ParseError.create)
-    ..aOM<PromptReplyResponse_UnsupportedValue>(10, _omitFieldNames ? '' : 'unsupportedValue', subBuilder: PromptReplyResponse_UnsupportedValue.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOM<$0.Empty>(2, _omitFieldNames ? '' : 'success',
+        subBuilder: $0.Empty.create)
+    ..aOM<$0.Empty>(3, _omitFieldNames ? '' : 'raw',
+        subBuilder: $0.Empty.create)
+    ..aOM<$0.Empty>(4, _omitFieldNames ? '' : 'promptNotFound',
+        subBuilder: $0.Empty.create)
+    ..aOM<$0.Empty>(5, _omitFieldNames ? '' : 'ruleNotFound',
+        subBuilder: $0.Empty.create)
+    ..aOM<PromptReplyResponse_HomeRuleConflicts>(
+        6, _omitFieldNames ? '' : 'ruleConflicts',
+        subBuilder: PromptReplyResponse_HomeRuleConflicts.create)
+    ..aOM<PromptReplyResponse_InvalidHomePermissions>(
+        7, _omitFieldNames ? '' : 'invalidPermissions',
+        subBuilder: PromptReplyResponse_InvalidHomePermissions.create)
+    ..aOM<PromptReplyResponse_InvalidPathPattern>(
+        8, _omitFieldNames ? '' : 'invalidPathPattern',
+        subBuilder: PromptReplyResponse_InvalidPathPattern.create)
+    ..aOM<PromptReplyResponse_ParseError>(
+        9, _omitFieldNames ? '' : 'parseError',
+        subBuilder: PromptReplyResponse_ParseError.create)
+    ..aOM<PromptReplyResponse_UnsupportedValue>(
+        10, _omitFieldNames ? '' : 'unsupportedValue',
+        subBuilder: PromptReplyResponse_UnsupportedValue.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PromptReplyResponse clone() => PromptReplyResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PromptReplyResponse copyWith(void Function(PromptReplyResponse) updates) => super.copyWith((message) => updates(message as PromptReplyResponse)) as PromptReplyResponse;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromptReplyResponse copyWith(void Function(PromptReplyResponse) updates) =>
+      super.copyWith((message) => updates(message as PromptReplyResponse))
+          as PromptReplyResponse;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static PromptReplyResponse create() => PromptReplyResponse._();
+  @$core.override
   PromptReplyResponse createEmptyInstance() => create();
-  static $pb.PbList<PromptReplyResponse> createRepeated() => $pb.PbList<PromptReplyResponse>();
+  static $pb.PbList<PromptReplyResponse> createRepeated() =>
+      $pb.PbList<PromptReplyResponse>();
   @$core.pragma('dart2js:noInline')
-  static PromptReplyResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PromptReplyResponse>(create);
+  static PromptReplyResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<PromptReplyResponse>(create);
   static PromptReplyResponse? _defaultInstance;
 
-  PromptReplyResponse_PromptReplyType whichPromptReplyType() => _PromptReplyResponse_PromptReplyTypeByTag[$_whichOneof(0)]!;
-  void clearPromptReplyType() => clearField($_whichOneof(0));
+  PromptReplyResponse_PromptReplyType whichPromptReplyType() =>
+      _PromptReplyResponse_PromptReplyTypeByTag[$_whichOneof(0)]!;
+  void clearPromptReplyType() => $_clearField($_whichOneof(0));
 
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
   @$pb.TagNumber(1)
-  set message($core.String v) { $_setString(0, v); }
+  set message($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasMessage() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMessage() => clearField(1);
+  void clearMessage() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $0.Empty get success => $_getN(1);
   @$pb.TagNumber(2)
-  set success($0.Empty v) { setField(2, v); }
+  set success($0.Empty value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasSuccess() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSuccess() => clearField(2);
+  void clearSuccess() => $_clearField(2);
   @$pb.TagNumber(2)
   $0.Empty ensureSuccess() => $_ensure(1);
 
   @$pb.TagNumber(3)
   $0.Empty get raw => $_getN(2);
   @$pb.TagNumber(3)
-  set raw($0.Empty v) { setField(3, v); }
+  set raw($0.Empty value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasRaw() => $_has(2);
   @$pb.TagNumber(3)
-  void clearRaw() => clearField(3);
+  void clearRaw() => $_clearField(3);
   @$pb.TagNumber(3)
   $0.Empty ensureRaw() => $_ensure(2);
 
   @$pb.TagNumber(4)
   $0.Empty get promptNotFound => $_getN(3);
   @$pb.TagNumber(4)
-  set promptNotFound($0.Empty v) { setField(4, v); }
+  set promptNotFound($0.Empty value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasPromptNotFound() => $_has(3);
   @$pb.TagNumber(4)
-  void clearPromptNotFound() => clearField(4);
+  void clearPromptNotFound() => $_clearField(4);
   @$pb.TagNumber(4)
   $0.Empty ensurePromptNotFound() => $_ensure(3);
 
   @$pb.TagNumber(5)
   $0.Empty get ruleNotFound => $_getN(4);
   @$pb.TagNumber(5)
-  set ruleNotFound($0.Empty v) { setField(5, v); }
+  set ruleNotFound($0.Empty value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasRuleNotFound() => $_has(4);
   @$pb.TagNumber(5)
-  void clearRuleNotFound() => clearField(5);
+  void clearRuleNotFound() => $_clearField(5);
   @$pb.TagNumber(5)
   $0.Empty ensureRuleNotFound() => $_ensure(4);
 
   @$pb.TagNumber(6)
   PromptReplyResponse_HomeRuleConflicts get ruleConflicts => $_getN(5);
   @$pb.TagNumber(6)
-  set ruleConflicts(PromptReplyResponse_HomeRuleConflicts v) { setField(6, v); }
+  set ruleConflicts(PromptReplyResponse_HomeRuleConflicts value) =>
+      $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasRuleConflicts() => $_has(5);
   @$pb.TagNumber(6)
-  void clearRuleConflicts() => clearField(6);
+  void clearRuleConflicts() => $_clearField(6);
   @$pb.TagNumber(6)
   PromptReplyResponse_HomeRuleConflicts ensureRuleConflicts() => $_ensure(5);
 
   @$pb.TagNumber(7)
-  PromptReplyResponse_InvalidHomePermissions get invalidPermissions => $_getN(6);
+  PromptReplyResponse_InvalidHomePermissions get invalidPermissions =>
+      $_getN(6);
   @$pb.TagNumber(7)
-  set invalidPermissions(PromptReplyResponse_InvalidHomePermissions v) { setField(7, v); }
+  set invalidPermissions(PromptReplyResponse_InvalidHomePermissions value) =>
+      $_setField(7, value);
   @$pb.TagNumber(7)
   $core.bool hasInvalidPermissions() => $_has(6);
   @$pb.TagNumber(7)
-  void clearInvalidPermissions() => clearField(7);
+  void clearInvalidPermissions() => $_clearField(7);
   @$pb.TagNumber(7)
-  PromptReplyResponse_InvalidHomePermissions ensureInvalidPermissions() => $_ensure(6);
+  PromptReplyResponse_InvalidHomePermissions ensureInvalidPermissions() =>
+      $_ensure(6);
 
   @$pb.TagNumber(8)
   PromptReplyResponse_InvalidPathPattern get invalidPathPattern => $_getN(7);
   @$pb.TagNumber(8)
-  set invalidPathPattern(PromptReplyResponse_InvalidPathPattern v) { setField(8, v); }
+  set invalidPathPattern(PromptReplyResponse_InvalidPathPattern value) =>
+      $_setField(8, value);
   @$pb.TagNumber(8)
   $core.bool hasInvalidPathPattern() => $_has(7);
   @$pb.TagNumber(8)
-  void clearInvalidPathPattern() => clearField(8);
+  void clearInvalidPathPattern() => $_clearField(8);
   @$pb.TagNumber(8)
-  PromptReplyResponse_InvalidPathPattern ensureInvalidPathPattern() => $_ensure(7);
+  PromptReplyResponse_InvalidPathPattern ensureInvalidPathPattern() =>
+      $_ensure(7);
 
   @$pb.TagNumber(9)
   PromptReplyResponse_ParseError get parseError => $_getN(8);
   @$pb.TagNumber(9)
-  set parseError(PromptReplyResponse_ParseError v) { setField(9, v); }
+  set parseError(PromptReplyResponse_ParseError value) => $_setField(9, value);
   @$pb.TagNumber(9)
   $core.bool hasParseError() => $_has(8);
   @$pb.TagNumber(9)
-  void clearParseError() => clearField(9);
+  void clearParseError() => $_clearField(9);
   @$pb.TagNumber(9)
   PromptReplyResponse_ParseError ensureParseError() => $_ensure(8);
 
   @$pb.TagNumber(10)
   PromptReplyResponse_UnsupportedValue get unsupportedValue => $_getN(9);
   @$pb.TagNumber(10)
-  set unsupportedValue(PromptReplyResponse_UnsupportedValue v) { setField(10, v); }
+  set unsupportedValue(PromptReplyResponse_UnsupportedValue value) =>
+      $_setField(10, value);
   @$pb.TagNumber(10)
   $core.bool hasUnsupportedValue() => $_has(9);
   @$pb.TagNumber(10)
-  void clearUnsupportedValue() => clearField(10);
+  void clearUnsupportedValue() => $_clearField(10);
   @$pb.TagNumber(10)
   PromptReplyResponse_UnsupportedValue ensureUnsupportedValue() => $_ensure(9);
 }
 
-enum GetCurrentPromptResponse_Prompt {
-  homePrompt, 
-  notSet
-}
+enum GetCurrentPromptResponse_Prompt { homePrompt, notSet }
 
 class GetCurrentPromptResponse extends $pb.GeneratedMessage {
   factory GetCurrentPromptResponse({
     HomePrompt? homePrompt,
   }) {
-    final $result = create();
-    if (homePrompt != null) {
-      $result.homePrompt = homePrompt;
-    }
-    return $result;
+    final result = create();
+    if (homePrompt != null) result.homePrompt = homePrompt;
+    return result;
   }
-  GetCurrentPromptResponse._() : super();
-  factory GetCurrentPromptResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetCurrentPromptResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static const $core.Map<$core.int, GetCurrentPromptResponse_Prompt> _GetCurrentPromptResponse_PromptByTag = {
-    1 : GetCurrentPromptResponse_Prompt.homePrompt,
-    0 : GetCurrentPromptResponse_Prompt.notSet
+  GetCurrentPromptResponse._();
+
+  factory GetCurrentPromptResponse.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory GetCurrentPromptResponse.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static const $core.Map<$core.int, GetCurrentPromptResponse_Prompt>
+      _GetCurrentPromptResponse_PromptByTag = {
+    1: GetCurrentPromptResponse_Prompt.homePrompt,
+    0: GetCurrentPromptResponse_Prompt.notSet
   };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetCurrentPromptResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'GetCurrentPromptResponse',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..oo(0, [1])
-    ..aOM<HomePrompt>(1, _omitFieldNames ? '' : 'homePrompt', subBuilder: HomePrompt.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOM<HomePrompt>(1, _omitFieldNames ? '' : 'homePrompt',
+        subBuilder: HomePrompt.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  GetCurrentPromptResponse clone() => GetCurrentPromptResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetCurrentPromptResponse copyWith(void Function(GetCurrentPromptResponse) updates) => super.copyWith((message) => updates(message as GetCurrentPromptResponse)) as GetCurrentPromptResponse;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetCurrentPromptResponse clone() =>
+      GetCurrentPromptResponse()..mergeFromMessage(this);
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetCurrentPromptResponse copyWith(
+          void Function(GetCurrentPromptResponse) updates) =>
+      super.copyWith((message) => updates(message as GetCurrentPromptResponse))
+          as GetCurrentPromptResponse;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetCurrentPromptResponse create() => GetCurrentPromptResponse._();
+  @$core.override
   GetCurrentPromptResponse createEmptyInstance() => create();
-  static $pb.PbList<GetCurrentPromptResponse> createRepeated() => $pb.PbList<GetCurrentPromptResponse>();
+  static $pb.PbList<GetCurrentPromptResponse> createRepeated() =>
+      $pb.PbList<GetCurrentPromptResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetCurrentPromptResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCurrentPromptResponse>(create);
+  static GetCurrentPromptResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GetCurrentPromptResponse>(create);
   static GetCurrentPromptResponse? _defaultInstance;
 
-  GetCurrentPromptResponse_Prompt whichPrompt() => _GetCurrentPromptResponse_PromptByTag[$_whichOneof(0)]!;
-  void clearPrompt() => clearField($_whichOneof(0));
+  GetCurrentPromptResponse_Prompt whichPrompt() =>
+      _GetCurrentPromptResponse_PromptByTag[$_whichOneof(0)]!;
+  void clearPrompt() => $_clearField($_whichOneof(0));
 
   @$pb.TagNumber(1)
   HomePrompt get homePrompt => $_getN(0);
   @$pb.TagNumber(1)
-  set homePrompt(HomePrompt v) { setField(1, v); }
+  set homePrompt(HomePrompt value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasHomePrompt() => $_has(0);
   @$pb.TagNumber(1)
-  void clearHomePrompt() => clearField(1);
+  void clearHomePrompt() => $_clearField(1);
   @$pb.TagNumber(1)
   HomePrompt ensureHomePrompt() => $_ensure(0);
 }
@@ -786,57 +896,66 @@ class HomePromptReply extends $pb.GeneratedMessage {
     $core.String? pathPattern,
     $core.Iterable<HomePermission>? permissions,
   }) {
-    final $result = create();
-    if (pathPattern != null) {
-      $result.pathPattern = pathPattern;
-    }
-    if (permissions != null) {
-      $result.permissions.addAll(permissions);
-    }
-    return $result;
+    final result = create();
+    if (pathPattern != null) result.pathPattern = pathPattern;
+    if (permissions != null) result.permissions.addAll(permissions);
+    return result;
   }
-  HomePromptReply._() : super();
-  factory HomePromptReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory HomePromptReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'HomePromptReply', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  HomePromptReply._();
+
+  factory HomePromptReply.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory HomePromptReply.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'HomePromptReply',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'pathPattern')
-    ..pc<HomePermission>(2, _omitFieldNames ? '' : 'permissions', $pb.PbFieldType.KE, valueOf: HomePermission.valueOf, enumValues: HomePermission.values, defaultEnumValue: HomePermission.READ)
-    ..hasRequiredFields = false
-  ;
+    ..pc<HomePermission>(
+        2, _omitFieldNames ? '' : 'permissions', $pb.PbFieldType.KE,
+        valueOf: HomePermission.valueOf,
+        enumValues: HomePermission.values,
+        defaultEnumValue: HomePermission.READ)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   HomePromptReply clone() => HomePromptReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  HomePromptReply copyWith(void Function(HomePromptReply) updates) => super.copyWith((message) => updates(message as HomePromptReply)) as HomePromptReply;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  HomePromptReply copyWith(void Function(HomePromptReply) updates) =>
+      super.copyWith((message) => updates(message as HomePromptReply))
+          as HomePromptReply;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static HomePromptReply create() => HomePromptReply._();
+  @$core.override
   HomePromptReply createEmptyInstance() => create();
-  static $pb.PbList<HomePromptReply> createRepeated() => $pb.PbList<HomePromptReply>();
+  static $pb.PbList<HomePromptReply> createRepeated() =>
+      $pb.PbList<HomePromptReply>();
   @$core.pragma('dart2js:noInline')
-  static HomePromptReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<HomePromptReply>(create);
+  static HomePromptReply getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<HomePromptReply>(create);
   static HomePromptReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get pathPattern => $_getSZ(0);
   @$pb.TagNumber(1)
-  set pathPattern($core.String v) { $_setString(0, v); }
+  set pathPattern($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPathPattern() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPathPattern() => clearField(1);
+  void clearPathPattern() => $_clearField(1);
 
   @$pb.TagNumber(2)
-  $core.List<HomePermission> get permissions => $_getList(1);
+  $pb.PbList<HomePermission> get permissions => $_getList(1);
 }
 
 class HomePrompt_PatternOption extends $pb.GeneratedMessage {
@@ -845,76 +964,85 @@ class HomePrompt_PatternOption extends $pb.GeneratedMessage {
     $core.String? pathPattern,
     $core.bool? showInitially,
   }) {
-    final $result = create();
-    if (homePatternType != null) {
-      $result.homePatternType = homePatternType;
-    }
-    if (pathPattern != null) {
-      $result.pathPattern = pathPattern;
-    }
-    if (showInitially != null) {
-      $result.showInitially = showInitially;
-    }
-    return $result;
+    final result = create();
+    if (homePatternType != null) result.homePatternType = homePatternType;
+    if (pathPattern != null) result.pathPattern = pathPattern;
+    if (showInitially != null) result.showInitially = showInitially;
+    return result;
   }
-  HomePrompt_PatternOption._() : super();
-  factory HomePrompt_PatternOption.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory HomePrompt_PatternOption.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'HomePrompt.PatternOption', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
-    ..e<HomePatternType>(1, _omitFieldNames ? '' : 'homePatternType', $pb.PbFieldType.OE, defaultOrMaker: HomePatternType.REQUESTED_DIRECTORY, valueOf: HomePatternType.valueOf, enumValues: HomePatternType.values)
+  HomePrompt_PatternOption._();
+
+  factory HomePrompt_PatternOption.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory HomePrompt_PatternOption.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'HomePrompt.PatternOption',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
+    ..e<HomePatternType>(
+        1, _omitFieldNames ? '' : 'homePatternType', $pb.PbFieldType.OE,
+        defaultOrMaker: HomePatternType.REQUESTED_DIRECTORY,
+        valueOf: HomePatternType.valueOf,
+        enumValues: HomePatternType.values)
     ..aOS(2, _omitFieldNames ? '' : 'pathPattern')
     ..aOB(3, _omitFieldNames ? '' : 'showInitially')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  HomePrompt_PatternOption clone() => HomePrompt_PatternOption()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  HomePrompt_PatternOption copyWith(void Function(HomePrompt_PatternOption) updates) => super.copyWith((message) => updates(message as HomePrompt_PatternOption)) as HomePrompt_PatternOption;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  HomePrompt_PatternOption clone() =>
+      HomePrompt_PatternOption()..mergeFromMessage(this);
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  HomePrompt_PatternOption copyWith(
+          void Function(HomePrompt_PatternOption) updates) =>
+      super.copyWith((message) => updates(message as HomePrompt_PatternOption))
+          as HomePrompt_PatternOption;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static HomePrompt_PatternOption create() => HomePrompt_PatternOption._();
+  @$core.override
   HomePrompt_PatternOption createEmptyInstance() => create();
-  static $pb.PbList<HomePrompt_PatternOption> createRepeated() => $pb.PbList<HomePrompt_PatternOption>();
+  static $pb.PbList<HomePrompt_PatternOption> createRepeated() =>
+      $pb.PbList<HomePrompt_PatternOption>();
   @$core.pragma('dart2js:noInline')
-  static HomePrompt_PatternOption getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<HomePrompt_PatternOption>(create);
+  static HomePrompt_PatternOption getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<HomePrompt_PatternOption>(create);
   static HomePrompt_PatternOption? _defaultInstance;
 
   @$pb.TagNumber(1)
   HomePatternType get homePatternType => $_getN(0);
   @$pb.TagNumber(1)
-  set homePatternType(HomePatternType v) { setField(1, v); }
+  set homePatternType(HomePatternType value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasHomePatternType() => $_has(0);
   @$pb.TagNumber(1)
-  void clearHomePatternType() => clearField(1);
+  void clearHomePatternType() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $core.String get pathPattern => $_getSZ(1);
   @$pb.TagNumber(2)
-  set pathPattern($core.String v) { $_setString(1, v); }
+  set pathPattern($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasPathPattern() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPathPattern() => clearField(2);
+  void clearPathPattern() => $_clearField(2);
 
   @$pb.TagNumber(3)
   $core.bool get showInitially => $_getBF(2);
   @$pb.TagNumber(3)
-  set showInitially($core.bool v) { $_setBool(2, v); }
+  set showInitially($core.bool value) => $_setBool(2, value);
   @$pb.TagNumber(3)
   $core.bool hasShowInitially() => $_has(2);
   @$pb.TagNumber(3)
-  void clearShowInitially() => clearField(3);
+  void clearShowInitially() => $_clearField(3);
 }
 
 class HomePrompt extends $pb.GeneratedMessage {
@@ -929,132 +1057,142 @@ class HomePrompt extends $pb.GeneratedMessage {
     $core.int? initialPatternOption,
     EnrichedPathKind? enrichedPathKind,
   }) {
-    final $result = create();
-    if (metaData != null) {
-      $result.metaData = metaData;
-    }
-    if (requestedPath != null) {
-      $result.requestedPath = requestedPath;
-    }
-    if (homeDir != null) {
-      $result.homeDir = homeDir;
-    }
-    if (requestedPermissions != null) {
-      $result.requestedPermissions.addAll(requestedPermissions);
-    }
-    if (availablePermissions != null) {
-      $result.availablePermissions.addAll(availablePermissions);
-    }
-    if (suggestedPermissions != null) {
-      $result.suggestedPermissions.addAll(suggestedPermissions);
-    }
-    if (patternOptions != null) {
-      $result.patternOptions.addAll(patternOptions);
-    }
-    if (initialPatternOption != null) {
-      $result.initialPatternOption = initialPatternOption;
-    }
-    if (enrichedPathKind != null) {
-      $result.enrichedPathKind = enrichedPathKind;
-    }
-    return $result;
+    final result = create();
+    if (metaData != null) result.metaData = metaData;
+    if (requestedPath != null) result.requestedPath = requestedPath;
+    if (homeDir != null) result.homeDir = homeDir;
+    if (requestedPermissions != null)
+      result.requestedPermissions.addAll(requestedPermissions);
+    if (availablePermissions != null)
+      result.availablePermissions.addAll(availablePermissions);
+    if (suggestedPermissions != null)
+      result.suggestedPermissions.addAll(suggestedPermissions);
+    if (patternOptions != null) result.patternOptions.addAll(patternOptions);
+    if (initialPatternOption != null)
+      result.initialPatternOption = initialPatternOption;
+    if (enrichedPathKind != null) result.enrichedPathKind = enrichedPathKind;
+    return result;
   }
-  HomePrompt._() : super();
-  factory HomePrompt.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory HomePrompt.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'HomePrompt', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
-    ..aOM<MetaData>(1, _omitFieldNames ? '' : 'metaData', subBuilder: MetaData.create)
+  HomePrompt._();
+
+  factory HomePrompt.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory HomePrompt.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'HomePrompt',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
+    ..aOM<MetaData>(1, _omitFieldNames ? '' : 'metaData',
+        subBuilder: MetaData.create)
     ..aOS(2, _omitFieldNames ? '' : 'requestedPath')
     ..aOS(3, _omitFieldNames ? '' : 'homeDir')
-    ..pc<HomePermission>(4, _omitFieldNames ? '' : 'requestedPermissions', $pb.PbFieldType.KE, valueOf: HomePermission.valueOf, enumValues: HomePermission.values, defaultEnumValue: HomePermission.READ)
-    ..pc<HomePermission>(5, _omitFieldNames ? '' : 'availablePermissions', $pb.PbFieldType.KE, valueOf: HomePermission.valueOf, enumValues: HomePermission.values, defaultEnumValue: HomePermission.READ)
-    ..pc<HomePermission>(6, _omitFieldNames ? '' : 'suggestedPermissions', $pb.PbFieldType.KE, valueOf: HomePermission.valueOf, enumValues: HomePermission.values, defaultEnumValue: HomePermission.READ)
-    ..pc<HomePrompt_PatternOption>(7, _omitFieldNames ? '' : 'patternOptions', $pb.PbFieldType.PM, subBuilder: HomePrompt_PatternOption.create)
-    ..a<$core.int>(8, _omitFieldNames ? '' : 'initialPatternOption', $pb.PbFieldType.O3)
-    ..aOM<EnrichedPathKind>(9, _omitFieldNames ? '' : 'enrichedPathKind', subBuilder: EnrichedPathKind.create)
-    ..hasRequiredFields = false
-  ;
+    ..pc<HomePermission>(
+        4, _omitFieldNames ? '' : 'requestedPermissions', $pb.PbFieldType.KE,
+        valueOf: HomePermission.valueOf,
+        enumValues: HomePermission.values,
+        defaultEnumValue: HomePermission.READ)
+    ..pc<HomePermission>(
+        5, _omitFieldNames ? '' : 'availablePermissions', $pb.PbFieldType.KE,
+        valueOf: HomePermission.valueOf,
+        enumValues: HomePermission.values,
+        defaultEnumValue: HomePermission.READ)
+    ..pc<HomePermission>(
+        6, _omitFieldNames ? '' : 'suggestedPermissions', $pb.PbFieldType.KE,
+        valueOf: HomePermission.valueOf,
+        enumValues: HomePermission.values,
+        defaultEnumValue: HomePermission.READ)
+    ..pc<HomePrompt_PatternOption>(
+        7, _omitFieldNames ? '' : 'patternOptions', $pb.PbFieldType.PM,
+        subBuilder: HomePrompt_PatternOption.create)
+    ..a<$core.int>(
+        8, _omitFieldNames ? '' : 'initialPatternOption', $pb.PbFieldType.O3)
+    ..aOM<EnrichedPathKind>(9, _omitFieldNames ? '' : 'enrichedPathKind',
+        subBuilder: EnrichedPathKind.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   HomePrompt clone() => HomePrompt()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  HomePrompt copyWith(void Function(HomePrompt) updates) => super.copyWith((message) => updates(message as HomePrompt)) as HomePrompt;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  HomePrompt copyWith(void Function(HomePrompt) updates) =>
+      super.copyWith((message) => updates(message as HomePrompt)) as HomePrompt;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static HomePrompt create() => HomePrompt._();
+  @$core.override
   HomePrompt createEmptyInstance() => create();
   static $pb.PbList<HomePrompt> createRepeated() => $pb.PbList<HomePrompt>();
   @$core.pragma('dart2js:noInline')
-  static HomePrompt getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<HomePrompt>(create);
+  static HomePrompt getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<HomePrompt>(create);
   static HomePrompt? _defaultInstance;
 
   @$pb.TagNumber(1)
   MetaData get metaData => $_getN(0);
   @$pb.TagNumber(1)
-  set metaData(MetaData v) { setField(1, v); }
+  set metaData(MetaData value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasMetaData() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMetaData() => clearField(1);
+  void clearMetaData() => $_clearField(1);
   @$pb.TagNumber(1)
   MetaData ensureMetaData() => $_ensure(0);
 
   @$pb.TagNumber(2)
   $core.String get requestedPath => $_getSZ(1);
   @$pb.TagNumber(2)
-  set requestedPath($core.String v) { $_setString(1, v); }
+  set requestedPath($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasRequestedPath() => $_has(1);
   @$pb.TagNumber(2)
-  void clearRequestedPath() => clearField(2);
+  void clearRequestedPath() => $_clearField(2);
 
   @$pb.TagNumber(3)
   $core.String get homeDir => $_getSZ(2);
   @$pb.TagNumber(3)
-  set homeDir($core.String v) { $_setString(2, v); }
+  set homeDir($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasHomeDir() => $_has(2);
   @$pb.TagNumber(3)
-  void clearHomeDir() => clearField(3);
+  void clearHomeDir() => $_clearField(3);
 
   @$pb.TagNumber(4)
-  $core.List<HomePermission> get requestedPermissions => $_getList(3);
+  $pb.PbList<HomePermission> get requestedPermissions => $_getList(3);
 
   @$pb.TagNumber(5)
-  $core.List<HomePermission> get availablePermissions => $_getList(4);
+  $pb.PbList<HomePermission> get availablePermissions => $_getList(4);
 
   @$pb.TagNumber(6)
-  $core.List<HomePermission> get suggestedPermissions => $_getList(5);
+  $pb.PbList<HomePermission> get suggestedPermissions => $_getList(5);
 
   @$pb.TagNumber(7)
-  $core.List<HomePrompt_PatternOption> get patternOptions => $_getList(6);
+  $pb.PbList<HomePrompt_PatternOption> get patternOptions => $_getList(6);
 
   @$pb.TagNumber(8)
   $core.int get initialPatternOption => $_getIZ(7);
   @$pb.TagNumber(8)
-  set initialPatternOption($core.int v) { $_setSignedInt32(7, v); }
+  set initialPatternOption($core.int value) => $_setSignedInt32(7, value);
   @$pb.TagNumber(8)
   $core.bool hasInitialPatternOption() => $_has(7);
   @$pb.TagNumber(8)
-  void clearInitialPatternOption() => clearField(8);
+  void clearInitialPatternOption() => $_clearField(8);
 
   @$pb.TagNumber(9)
   EnrichedPathKind get enrichedPathKind => $_getN(8);
   @$pb.TagNumber(9)
-  set enrichedPathKind(EnrichedPathKind v) { setField(9, v); }
+  set enrichedPathKind(EnrichedPathKind value) => $_setField(9, value);
   @$pb.TagNumber(9)
   $core.bool hasEnrichedPathKind() => $_has(8);
   @$pb.TagNumber(9)
-  void clearEnrichedPathKind() => clearField(9);
+  void clearEnrichedPathKind() => $_clearField(9);
   @$pb.TagNumber(9)
   EnrichedPathKind ensureEnrichedPathKind() => $_ensure(8);
 }
@@ -1067,211 +1205,232 @@ class MetaData extends $pb.GeneratedMessage {
     $core.String? publisher,
     $core.String? updatedAt,
   }) {
-    final $result = create();
-    if (promptId != null) {
-      $result.promptId = promptId;
-    }
-    if (snapName != null) {
-      $result.snapName = snapName;
-    }
-    if (storeUrl != null) {
-      $result.storeUrl = storeUrl;
-    }
-    if (publisher != null) {
-      $result.publisher = publisher;
-    }
-    if (updatedAt != null) {
-      $result.updatedAt = updatedAt;
-    }
-    return $result;
+    final result = create();
+    if (promptId != null) result.promptId = promptId;
+    if (snapName != null) result.snapName = snapName;
+    if (storeUrl != null) result.storeUrl = storeUrl;
+    if (publisher != null) result.publisher = publisher;
+    if (updatedAt != null) result.updatedAt = updatedAt;
+    return result;
   }
-  MetaData._() : super();
-  factory MetaData.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory MetaData.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MetaData', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  MetaData._();
+
+  factory MetaData.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MetaData.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'MetaData',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'promptId')
     ..aOS(2, _omitFieldNames ? '' : 'snapName')
     ..aOS(3, _omitFieldNames ? '' : 'storeUrl')
     ..aOS(4, _omitFieldNames ? '' : 'publisher')
     ..aOS(5, _omitFieldNames ? '' : 'updatedAt')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MetaData clone() => MetaData()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  MetaData copyWith(void Function(MetaData) updates) => super.copyWith((message) => updates(message as MetaData)) as MetaData;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MetaData copyWith(void Function(MetaData) updates) =>
+      super.copyWith((message) => updates(message as MetaData)) as MetaData;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static MetaData create() => MetaData._();
+  @$core.override
   MetaData createEmptyInstance() => create();
   static $pb.PbList<MetaData> createRepeated() => $pb.PbList<MetaData>();
   @$core.pragma('dart2js:noInline')
-  static MetaData getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MetaData>(create);
+  static MetaData getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MetaData>(create);
   static MetaData? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get promptId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set promptId($core.String v) { $_setString(0, v); }
+  set promptId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPromptId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPromptId() => clearField(1);
+  void clearPromptId() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $core.String get snapName => $_getSZ(1);
   @$pb.TagNumber(2)
-  set snapName($core.String v) { $_setString(1, v); }
+  set snapName($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasSnapName() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSnapName() => clearField(2);
+  void clearSnapName() => $_clearField(2);
 
   @$pb.TagNumber(3)
   $core.String get storeUrl => $_getSZ(2);
   @$pb.TagNumber(3)
-  set storeUrl($core.String v) { $_setString(2, v); }
+  set storeUrl($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasStoreUrl() => $_has(2);
   @$pb.TagNumber(3)
-  void clearStoreUrl() => clearField(3);
+  void clearStoreUrl() => $_clearField(3);
 
   @$pb.TagNumber(4)
   $core.String get publisher => $_getSZ(3);
   @$pb.TagNumber(4)
-  set publisher($core.String v) { $_setString(3, v); }
+  set publisher($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasPublisher() => $_has(3);
   @$pb.TagNumber(4)
-  void clearPublisher() => clearField(4);
+  void clearPublisher() => $_clearField(4);
 
   @$pb.TagNumber(5)
   $core.String get updatedAt => $_getSZ(4);
   @$pb.TagNumber(5)
-  set updatedAt($core.String v) { $_setString(4, v); }
+  set updatedAt($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasUpdatedAt() => $_has(4);
   @$pb.TagNumber(5)
-  void clearUpdatedAt() => clearField(5);
+  void clearUpdatedAt() => $_clearField(5);
 }
 
 class ResolveHomePatternTypeResponse extends $pb.GeneratedMessage {
   factory ResolveHomePatternTypeResponse({
     HomePatternType? homePatternType,
   }) {
-    final $result = create();
-    if (homePatternType != null) {
-      $result.homePatternType = homePatternType;
-    }
-    return $result;
+    final result = create();
+    if (homePatternType != null) result.homePatternType = homePatternType;
+    return result;
   }
-  ResolveHomePatternTypeResponse._() : super();
-  factory ResolveHomePatternTypeResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ResolveHomePatternTypeResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResolveHomePatternTypeResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
-    ..e<HomePatternType>(1, _omitFieldNames ? '' : 'homePatternType', $pb.PbFieldType.OE, defaultOrMaker: HomePatternType.REQUESTED_DIRECTORY, valueOf: HomePatternType.valueOf, enumValues: HomePatternType.values)
-    ..hasRequiredFields = false
-  ;
+  ResolveHomePatternTypeResponse._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  ResolveHomePatternTypeResponse clone() => ResolveHomePatternTypeResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ResolveHomePatternTypeResponse copyWith(void Function(ResolveHomePatternTypeResponse) updates) => super.copyWith((message) => updates(message as ResolveHomePatternTypeResponse)) as ResolveHomePatternTypeResponse;
+  factory ResolveHomePatternTypeResponse.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ResolveHomePatternTypeResponse.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
 
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ResolveHomePatternTypeResponse',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
+    ..e<HomePatternType>(
+        1, _omitFieldNames ? '' : 'homePatternType', $pb.PbFieldType.OE,
+        defaultOrMaker: HomePatternType.REQUESTED_DIRECTORY,
+        valueOf: HomePatternType.valueOf,
+        enumValues: HomePatternType.values)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ResolveHomePatternTypeResponse clone() =>
+      ResolveHomePatternTypeResponse()..mergeFromMessage(this);
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ResolveHomePatternTypeResponse copyWith(
+          void Function(ResolveHomePatternTypeResponse) updates) =>
+      super.copyWith(
+              (message) => updates(message as ResolveHomePatternTypeResponse))
+          as ResolveHomePatternTypeResponse;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
-  static ResolveHomePatternTypeResponse create() => ResolveHomePatternTypeResponse._();
+  static ResolveHomePatternTypeResponse create() =>
+      ResolveHomePatternTypeResponse._();
+  @$core.override
   ResolveHomePatternTypeResponse createEmptyInstance() => create();
-  static $pb.PbList<ResolveHomePatternTypeResponse> createRepeated() => $pb.PbList<ResolveHomePatternTypeResponse>();
+  static $pb.PbList<ResolveHomePatternTypeResponse> createRepeated() =>
+      $pb.PbList<ResolveHomePatternTypeResponse>();
   @$core.pragma('dart2js:noInline')
-  static ResolveHomePatternTypeResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResolveHomePatternTypeResponse>(create);
+  static ResolveHomePatternTypeResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ResolveHomePatternTypeResponse>(create);
   static ResolveHomePatternTypeResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   HomePatternType get homePatternType => $_getN(0);
   @$pb.TagNumber(1)
-  set homePatternType(HomePatternType v) { setField(1, v); }
+  set homePatternType(HomePatternType value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasHomePatternType() => $_has(0);
   @$pb.TagNumber(1)
-  void clearHomePatternType() => clearField(1);
+  void clearHomePatternType() => $_clearField(1);
 }
 
 class SetLoggingFilterResponse extends $pb.GeneratedMessage {
   factory SetLoggingFilterResponse({
     $core.String? current,
   }) {
-    final $result = create();
-    if (current != null) {
-      $result.current = current;
-    }
-    return $result;
+    final result = create();
+    if (current != null) result.current = current;
+    return result;
   }
-  SetLoggingFilterResponse._() : super();
-  factory SetLoggingFilterResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SetLoggingFilterResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetLoggingFilterResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  SetLoggingFilterResponse._();
+
+  factory SetLoggingFilterResponse.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory SetLoggingFilterResponse.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'SetLoggingFilterResponse',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'current')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  SetLoggingFilterResponse clone() => SetLoggingFilterResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SetLoggingFilterResponse copyWith(void Function(SetLoggingFilterResponse) updates) => super.copyWith((message) => updates(message as SetLoggingFilterResponse)) as SetLoggingFilterResponse;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  SetLoggingFilterResponse clone() =>
+      SetLoggingFilterResponse()..mergeFromMessage(this);
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  SetLoggingFilterResponse copyWith(
+          void Function(SetLoggingFilterResponse) updates) =>
+      super.copyWith((message) => updates(message as SetLoggingFilterResponse))
+          as SetLoggingFilterResponse;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SetLoggingFilterResponse create() => SetLoggingFilterResponse._();
+  @$core.override
   SetLoggingFilterResponse createEmptyInstance() => create();
-  static $pb.PbList<SetLoggingFilterResponse> createRepeated() => $pb.PbList<SetLoggingFilterResponse>();
+  static $pb.PbList<SetLoggingFilterResponse> createRepeated() =>
+      $pb.PbList<SetLoggingFilterResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetLoggingFilterResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetLoggingFilterResponse>(create);
+  static SetLoggingFilterResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<SetLoggingFilterResponse>(create);
   static SetLoggingFilterResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get current => $_getSZ(0);
   @$pb.TagNumber(1)
-  set current($core.String v) { $_setString(0, v); }
+  set current($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasCurrent() => $_has(0);
   @$pb.TagNumber(1)
-  void clearCurrent() => clearField(1);
+  void clearCurrent() => $_clearField(1);
 }
 
 enum EnrichedPathKind_Kind {
-  homeDir, 
-  topLevelDir, 
-  subDir, 
-  homeDirFile, 
-  topLevelDirFile, 
-  subDirFile, 
+  homeDir,
+  topLevelDir,
+  subDir,
+  homeDirFile,
+  topLevelDirFile,
+  subDirFile,
   notSet
 }
 
@@ -1284,171 +1443,182 @@ class EnrichedPathKind extends $pb.GeneratedMessage {
     TopLevelDirFile? topLevelDirFile,
     SubDirFile? subDirFile,
   }) {
-    final $result = create();
-    if (homeDir != null) {
-      $result.homeDir = homeDir;
-    }
-    if (topLevelDir != null) {
-      $result.topLevelDir = topLevelDir;
-    }
-    if (subDir != null) {
-      $result.subDir = subDir;
-    }
-    if (homeDirFile != null) {
-      $result.homeDirFile = homeDirFile;
-    }
-    if (topLevelDirFile != null) {
-      $result.topLevelDirFile = topLevelDirFile;
-    }
-    if (subDirFile != null) {
-      $result.subDirFile = subDirFile;
-    }
-    return $result;
+    final result = create();
+    if (homeDir != null) result.homeDir = homeDir;
+    if (topLevelDir != null) result.topLevelDir = topLevelDir;
+    if (subDir != null) result.subDir = subDir;
+    if (homeDirFile != null) result.homeDirFile = homeDirFile;
+    if (topLevelDirFile != null) result.topLevelDirFile = topLevelDirFile;
+    if (subDirFile != null) result.subDirFile = subDirFile;
+    return result;
   }
-  EnrichedPathKind._() : super();
-  factory EnrichedPathKind.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory EnrichedPathKind.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static const $core.Map<$core.int, EnrichedPathKind_Kind> _EnrichedPathKind_KindByTag = {
-    1 : EnrichedPathKind_Kind.homeDir,
-    2 : EnrichedPathKind_Kind.topLevelDir,
-    3 : EnrichedPathKind_Kind.subDir,
-    4 : EnrichedPathKind_Kind.homeDirFile,
-    5 : EnrichedPathKind_Kind.topLevelDirFile,
-    6 : EnrichedPathKind_Kind.subDirFile,
-    0 : EnrichedPathKind_Kind.notSet
+  EnrichedPathKind._();
+
+  factory EnrichedPathKind.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory EnrichedPathKind.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static const $core.Map<$core.int, EnrichedPathKind_Kind>
+      _EnrichedPathKind_KindByTag = {
+    1: EnrichedPathKind_Kind.homeDir,
+    2: EnrichedPathKind_Kind.topLevelDir,
+    3: EnrichedPathKind_Kind.subDir,
+    4: EnrichedPathKind_Kind.homeDirFile,
+    5: EnrichedPathKind_Kind.topLevelDirFile,
+    6: EnrichedPathKind_Kind.subDirFile,
+    0: EnrichedPathKind_Kind.notSet
   };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EnrichedPathKind', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'EnrichedPathKind',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..oo(0, [1, 2, 3, 4, 5, 6])
-    ..aOM<HomeDir>(1, _omitFieldNames ? '' : 'homeDir', subBuilder: HomeDir.create)
-    ..aOM<TopLevelDir>(2, _omitFieldNames ? '' : 'topLevelDir', subBuilder: TopLevelDir.create)
+    ..aOM<HomeDir>(1, _omitFieldNames ? '' : 'homeDir',
+        subBuilder: HomeDir.create)
+    ..aOM<TopLevelDir>(2, _omitFieldNames ? '' : 'topLevelDir',
+        subBuilder: TopLevelDir.create)
     ..aOM<SubDir>(3, _omitFieldNames ? '' : 'subDir', subBuilder: SubDir.create)
-    ..aOM<HomeDirFile>(4, _omitFieldNames ? '' : 'homeDirFile', subBuilder: HomeDirFile.create)
-    ..aOM<TopLevelDirFile>(5, _omitFieldNames ? '' : 'topLevelDirFile', subBuilder: TopLevelDirFile.create)
-    ..aOM<SubDirFile>(6, _omitFieldNames ? '' : 'subDirFile', subBuilder: SubDirFile.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOM<HomeDirFile>(4, _omitFieldNames ? '' : 'homeDirFile',
+        subBuilder: HomeDirFile.create)
+    ..aOM<TopLevelDirFile>(5, _omitFieldNames ? '' : 'topLevelDirFile',
+        subBuilder: TopLevelDirFile.create)
+    ..aOM<SubDirFile>(6, _omitFieldNames ? '' : 'subDirFile',
+        subBuilder: SubDirFile.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   EnrichedPathKind clone() => EnrichedPathKind()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  EnrichedPathKind copyWith(void Function(EnrichedPathKind) updates) => super.copyWith((message) => updates(message as EnrichedPathKind)) as EnrichedPathKind;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  EnrichedPathKind copyWith(void Function(EnrichedPathKind) updates) =>
+      super.copyWith((message) => updates(message as EnrichedPathKind))
+          as EnrichedPathKind;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static EnrichedPathKind create() => EnrichedPathKind._();
+  @$core.override
   EnrichedPathKind createEmptyInstance() => create();
-  static $pb.PbList<EnrichedPathKind> createRepeated() => $pb.PbList<EnrichedPathKind>();
+  static $pb.PbList<EnrichedPathKind> createRepeated() =>
+      $pb.PbList<EnrichedPathKind>();
   @$core.pragma('dart2js:noInline')
-  static EnrichedPathKind getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EnrichedPathKind>(create);
+  static EnrichedPathKind getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<EnrichedPathKind>(create);
   static EnrichedPathKind? _defaultInstance;
 
-  EnrichedPathKind_Kind whichKind() => _EnrichedPathKind_KindByTag[$_whichOneof(0)]!;
-  void clearKind() => clearField($_whichOneof(0));
+  EnrichedPathKind_Kind whichKind() =>
+      _EnrichedPathKind_KindByTag[$_whichOneof(0)]!;
+  void clearKind() => $_clearField($_whichOneof(0));
 
   @$pb.TagNumber(1)
   HomeDir get homeDir => $_getN(0);
   @$pb.TagNumber(1)
-  set homeDir(HomeDir v) { setField(1, v); }
+  set homeDir(HomeDir value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasHomeDir() => $_has(0);
   @$pb.TagNumber(1)
-  void clearHomeDir() => clearField(1);
+  void clearHomeDir() => $_clearField(1);
   @$pb.TagNumber(1)
   HomeDir ensureHomeDir() => $_ensure(0);
 
   @$pb.TagNumber(2)
   TopLevelDir get topLevelDir => $_getN(1);
   @$pb.TagNumber(2)
-  set topLevelDir(TopLevelDir v) { setField(2, v); }
+  set topLevelDir(TopLevelDir value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasTopLevelDir() => $_has(1);
   @$pb.TagNumber(2)
-  void clearTopLevelDir() => clearField(2);
+  void clearTopLevelDir() => $_clearField(2);
   @$pb.TagNumber(2)
   TopLevelDir ensureTopLevelDir() => $_ensure(1);
 
   @$pb.TagNumber(3)
   SubDir get subDir => $_getN(2);
   @$pb.TagNumber(3)
-  set subDir(SubDir v) { setField(3, v); }
+  set subDir(SubDir value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasSubDir() => $_has(2);
   @$pb.TagNumber(3)
-  void clearSubDir() => clearField(3);
+  void clearSubDir() => $_clearField(3);
   @$pb.TagNumber(3)
   SubDir ensureSubDir() => $_ensure(2);
 
   @$pb.TagNumber(4)
   HomeDirFile get homeDirFile => $_getN(3);
   @$pb.TagNumber(4)
-  set homeDirFile(HomeDirFile v) { setField(4, v); }
+  set homeDirFile(HomeDirFile value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasHomeDirFile() => $_has(3);
   @$pb.TagNumber(4)
-  void clearHomeDirFile() => clearField(4);
+  void clearHomeDirFile() => $_clearField(4);
   @$pb.TagNumber(4)
   HomeDirFile ensureHomeDirFile() => $_ensure(3);
 
   @$pb.TagNumber(5)
   TopLevelDirFile get topLevelDirFile => $_getN(4);
   @$pb.TagNumber(5)
-  set topLevelDirFile(TopLevelDirFile v) { setField(5, v); }
+  set topLevelDirFile(TopLevelDirFile value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasTopLevelDirFile() => $_has(4);
   @$pb.TagNumber(5)
-  void clearTopLevelDirFile() => clearField(5);
+  void clearTopLevelDirFile() => $_clearField(5);
   @$pb.TagNumber(5)
   TopLevelDirFile ensureTopLevelDirFile() => $_ensure(4);
 
   @$pb.TagNumber(6)
   SubDirFile get subDirFile => $_getN(5);
   @$pb.TagNumber(6)
-  set subDirFile(SubDirFile v) { setField(6, v); }
+  set subDirFile(SubDirFile value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasSubDirFile() => $_has(5);
   @$pb.TagNumber(6)
-  void clearSubDirFile() => clearField(6);
+  void clearSubDirFile() => $_clearField(6);
   @$pb.TagNumber(6)
   SubDirFile ensureSubDirFile() => $_ensure(5);
 }
 
 class HomeDir extends $pb.GeneratedMessage {
   factory HomeDir() => create();
-  HomeDir._() : super();
-  factory HomeDir.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory HomeDir.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'HomeDir', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  HomeDir._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory HomeDir.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory HomeDir.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'HomeDir',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   HomeDir clone() => HomeDir()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  HomeDir copyWith(void Function(HomeDir) updates) => super.copyWith((message) => updates(message as HomeDir)) as HomeDir;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  HomeDir copyWith(void Function(HomeDir) updates) =>
+      super.copyWith((message) => updates(message as HomeDir)) as HomeDir;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static HomeDir create() => HomeDir._();
+  @$core.override
   HomeDir createEmptyInstance() => create();
   static $pb.PbList<HomeDir> createRepeated() => $pb.PbList<HomeDir>();
   @$core.pragma('dart2js:noInline')
-  static HomeDir getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<HomeDir>(create);
+  static HomeDir getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<HomeDir>(create);
   static HomeDir? _defaultInstance;
 }
 
@@ -1456,81 +1626,94 @@ class TopLevelDir extends $pb.GeneratedMessage {
   factory TopLevelDir({
     $core.String? dirname,
   }) {
-    final $result = create();
-    if (dirname != null) {
-      $result.dirname = dirname;
-    }
-    return $result;
+    final result = create();
+    if (dirname != null) result.dirname = dirname;
+    return result;
   }
-  TopLevelDir._() : super();
-  factory TopLevelDir.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory TopLevelDir.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TopLevelDir', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  TopLevelDir._();
+
+  factory TopLevelDir.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory TopLevelDir.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'TopLevelDir',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'dirname')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   TopLevelDir clone() => TopLevelDir()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  TopLevelDir copyWith(void Function(TopLevelDir) updates) => super.copyWith((message) => updates(message as TopLevelDir)) as TopLevelDir;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  TopLevelDir copyWith(void Function(TopLevelDir) updates) =>
+      super.copyWith((message) => updates(message as TopLevelDir))
+          as TopLevelDir;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static TopLevelDir create() => TopLevelDir._();
+  @$core.override
   TopLevelDir createEmptyInstance() => create();
   static $pb.PbList<TopLevelDir> createRepeated() => $pb.PbList<TopLevelDir>();
   @$core.pragma('dart2js:noInline')
-  static TopLevelDir getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TopLevelDir>(create);
+  static TopLevelDir getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<TopLevelDir>(create);
   static TopLevelDir? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get dirname => $_getSZ(0);
   @$pb.TagNumber(1)
-  set dirname($core.String v) { $_setString(0, v); }
+  set dirname($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasDirname() => $_has(0);
   @$pb.TagNumber(1)
-  void clearDirname() => clearField(1);
+  void clearDirname() => $_clearField(1);
 }
 
 class SubDir extends $pb.GeneratedMessage {
   factory SubDir() => create();
-  SubDir._() : super();
-  factory SubDir.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SubDir.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SubDir', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  SubDir._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SubDir.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory SubDir.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'SubDir',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   SubDir clone() => SubDir()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SubDir copyWith(void Function(SubDir) updates) => super.copyWith((message) => updates(message as SubDir)) as SubDir;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  SubDir copyWith(void Function(SubDir) updates) =>
+      super.copyWith((message) => updates(message as SubDir)) as SubDir;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SubDir create() => SubDir._();
+  @$core.override
   SubDir createEmptyInstance() => create();
   static $pb.PbList<SubDir> createRepeated() => $pb.PbList<SubDir>();
   @$core.pragma('dart2js:noInline')
-  static SubDir getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SubDir>(create);
+  static SubDir getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SubDir>(create);
   static SubDir? _defaultInstance;
 }
 
@@ -1538,50 +1721,56 @@ class HomeDirFile extends $pb.GeneratedMessage {
   factory HomeDirFile({
     $core.String? filename,
   }) {
-    final $result = create();
-    if (filename != null) {
-      $result.filename = filename;
-    }
-    return $result;
+    final result = create();
+    if (filename != null) result.filename = filename;
+    return result;
   }
-  HomeDirFile._() : super();
-  factory HomeDirFile.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory HomeDirFile.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'HomeDirFile', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  HomeDirFile._();
+
+  factory HomeDirFile.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory HomeDirFile.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'HomeDirFile',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'filename')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   HomeDirFile clone() => HomeDirFile()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  HomeDirFile copyWith(void Function(HomeDirFile) updates) => super.copyWith((message) => updates(message as HomeDirFile)) as HomeDirFile;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  HomeDirFile copyWith(void Function(HomeDirFile) updates) =>
+      super.copyWith((message) => updates(message as HomeDirFile))
+          as HomeDirFile;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static HomeDirFile create() => HomeDirFile._();
+  @$core.override
   HomeDirFile createEmptyInstance() => create();
   static $pb.PbList<HomeDirFile> createRepeated() => $pb.PbList<HomeDirFile>();
   @$core.pragma('dart2js:noInline')
-  static HomeDirFile getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<HomeDirFile>(create);
+  static HomeDirFile getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<HomeDirFile>(create);
   static HomeDirFile? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get filename => $_getSZ(0);
   @$pb.TagNumber(1)
-  set filename($core.String v) { $_setString(0, v); }
+  set filename($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasFilename() => $_has(0);
   @$pb.TagNumber(1)
-  void clearFilename() => clearField(1);
+  void clearFilename() => $_clearField(1);
 }
 
 class TopLevelDirFile extends $pb.GeneratedMessage {
@@ -1589,97 +1778,110 @@ class TopLevelDirFile extends $pb.GeneratedMessage {
     $core.String? dirname,
     $core.String? filename,
   }) {
-    final $result = create();
-    if (dirname != null) {
-      $result.dirname = dirname;
-    }
-    if (filename != null) {
-      $result.filename = filename;
-    }
-    return $result;
+    final result = create();
+    if (dirname != null) result.dirname = dirname;
+    if (filename != null) result.filename = filename;
+    return result;
   }
-  TopLevelDirFile._() : super();
-  factory TopLevelDirFile.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory TopLevelDirFile.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TopLevelDirFile', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
+  TopLevelDirFile._();
+
+  factory TopLevelDirFile.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory TopLevelDirFile.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'TopLevelDirFile',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'dirname')
     ..aOS(2, _omitFieldNames ? '' : 'filename')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   TopLevelDirFile clone() => TopLevelDirFile()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  TopLevelDirFile copyWith(void Function(TopLevelDirFile) updates) => super.copyWith((message) => updates(message as TopLevelDirFile)) as TopLevelDirFile;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  TopLevelDirFile copyWith(void Function(TopLevelDirFile) updates) =>
+      super.copyWith((message) => updates(message as TopLevelDirFile))
+          as TopLevelDirFile;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static TopLevelDirFile create() => TopLevelDirFile._();
+  @$core.override
   TopLevelDirFile createEmptyInstance() => create();
-  static $pb.PbList<TopLevelDirFile> createRepeated() => $pb.PbList<TopLevelDirFile>();
+  static $pb.PbList<TopLevelDirFile> createRepeated() =>
+      $pb.PbList<TopLevelDirFile>();
   @$core.pragma('dart2js:noInline')
-  static TopLevelDirFile getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TopLevelDirFile>(create);
+  static TopLevelDirFile getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<TopLevelDirFile>(create);
   static TopLevelDirFile? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get dirname => $_getSZ(0);
   @$pb.TagNumber(1)
-  set dirname($core.String v) { $_setString(0, v); }
+  set dirname($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasDirname() => $_has(0);
   @$pb.TagNumber(1)
-  void clearDirname() => clearField(1);
+  void clearDirname() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $core.String get filename => $_getSZ(1);
   @$pb.TagNumber(2)
-  set filename($core.String v) { $_setString(1, v); }
+  set filename($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasFilename() => $_has(1);
   @$pb.TagNumber(2)
-  void clearFilename() => clearField(2);
+  void clearFilename() => $_clearField(2);
 }
 
 class SubDirFile extends $pb.GeneratedMessage {
   factory SubDirFile() => create();
-  SubDirFile._() : super();
-  factory SubDirFile.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SubDirFile.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SubDirFile', package: const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  SubDirFile._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SubDirFile.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory SubDirFile.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'SubDirFile',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'apparmor_prompting'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   SubDirFile clone() => SubDirFile()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SubDirFile copyWith(void Function(SubDirFile) updates) => super.copyWith((message) => updates(message as SubDirFile)) as SubDirFile;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  SubDirFile copyWith(void Function(SubDirFile) updates) =>
+      super.copyWith((message) => updates(message as SubDirFile)) as SubDirFile;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SubDirFile create() => SubDirFile._();
+  @$core.override
   SubDirFile createEmptyInstance() => create();
   static $pb.PbList<SubDirFile> createRepeated() => $pb.PbList<SubDirFile>();
   @$core.pragma('dart2js:noInline')
-  static SubDirFile getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SubDirFile>(create);
+  static SubDirFile getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<SubDirFile>(create);
   static SubDirFile? _defaultInstance;
 }
 
-
-const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pbenum.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pbenum.dart
@@ -1,13 +1,14 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: apparmor-prompting.proto
-//
-// @dart = 2.12
+// Generated from apparmor-prompting.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:core' as $core;
 
@@ -17,61 +18,79 @@ class Action extends $pb.ProtobufEnum {
   static const Action ALLOW = Action._(0, _omitEnumNames ? '' : 'ALLOW');
   static const Action DENY = Action._(1, _omitEnumNames ? '' : 'DENY');
 
-  static const $core.List<Action> values = <Action> [
+  static const $core.List<Action> values = <Action>[
     ALLOW,
     DENY,
   ];
 
-  static final $core.Map<$core.int, Action> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static Action? valueOf($core.int value) => _byValue[value];
+  static final $core.List<Action?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 1);
+  static Action? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const Action._($core.int v, $core.String n) : super(v, n);
+  const Action._(super.value, super.name);
 }
 
 class Lifespan extends $pb.ProtobufEnum {
   static const Lifespan SINGLE = Lifespan._(0, _omitEnumNames ? '' : 'SINGLE');
-  static const Lifespan SESSION = Lifespan._(1, _omitEnumNames ? '' : 'SESSION');
-  static const Lifespan FOREVER = Lifespan._(2, _omitEnumNames ? '' : 'FOREVER');
+  static const Lifespan SESSION =
+      Lifespan._(1, _omitEnumNames ? '' : 'SESSION');
+  static const Lifespan FOREVER =
+      Lifespan._(2, _omitEnumNames ? '' : 'FOREVER');
 
-  static const $core.List<Lifespan> values = <Lifespan> [
+  static const $core.List<Lifespan> values = <Lifespan>[
     SINGLE,
     SESSION,
     FOREVER,
   ];
 
-  static final $core.Map<$core.int, Lifespan> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static Lifespan? valueOf($core.int value) => _byValue[value];
+  static final $core.List<Lifespan?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 2);
+  static Lifespan? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const Lifespan._($core.int v, $core.String n) : super(v, n);
+  const Lifespan._(super.value, super.name);
 }
 
 class HomePermission extends $pb.ProtobufEnum {
-  static const HomePermission READ = HomePermission._(0, _omitEnumNames ? '' : 'READ');
-  static const HomePermission WRITE = HomePermission._(1, _omitEnumNames ? '' : 'WRITE');
-  static const HomePermission EXECUTE = HomePermission._(2, _omitEnumNames ? '' : 'EXECUTE');
+  static const HomePermission READ =
+      HomePermission._(0, _omitEnumNames ? '' : 'READ');
+  static const HomePermission WRITE =
+      HomePermission._(1, _omitEnumNames ? '' : 'WRITE');
+  static const HomePermission EXECUTE =
+      HomePermission._(2, _omitEnumNames ? '' : 'EXECUTE');
 
-  static const $core.List<HomePermission> values = <HomePermission> [
+  static const $core.List<HomePermission> values = <HomePermission>[
     READ,
     WRITE,
     EXECUTE,
   ];
 
-  static final $core.Map<$core.int, HomePermission> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static HomePermission? valueOf($core.int value) => _byValue[value];
+  static final $core.List<HomePermission?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 2);
+  static HomePermission? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const HomePermission._($core.int v, $core.String n) : super(v, n);
+  const HomePermission._(super.value, super.name);
 }
 
 class HomePatternType extends $pb.ProtobufEnum {
-  static const HomePatternType REQUESTED_DIRECTORY = HomePatternType._(0, _omitEnumNames ? '' : 'REQUESTED_DIRECTORY');
-  static const HomePatternType REQUESTED_FILE = HomePatternType._(1, _omitEnumNames ? '' : 'REQUESTED_FILE');
-  static const HomePatternType TOP_LEVEL_DIRECTORY = HomePatternType._(2, _omitEnumNames ? '' : 'TOP_LEVEL_DIRECTORY');
-  static const HomePatternType CONTAINING_DIRECTORY = HomePatternType._(3, _omitEnumNames ? '' : 'CONTAINING_DIRECTORY');
-  static const HomePatternType HOME_DIRECTORY = HomePatternType._(4, _omitEnumNames ? '' : 'HOME_DIRECTORY');
-  static const HomePatternType MATCHING_FILE_EXTENSION = HomePatternType._(5, _omitEnumNames ? '' : 'MATCHING_FILE_EXTENSION');
-  static const HomePatternType REQUESTED_DIRECTORY_CONTENTS = HomePatternType._(6, _omitEnumNames ? '' : 'REQUESTED_DIRECTORY_CONTENTS');
+  static const HomePatternType REQUESTED_DIRECTORY =
+      HomePatternType._(0, _omitEnumNames ? '' : 'REQUESTED_DIRECTORY');
+  static const HomePatternType REQUESTED_FILE =
+      HomePatternType._(1, _omitEnumNames ? '' : 'REQUESTED_FILE');
+  static const HomePatternType TOP_LEVEL_DIRECTORY =
+      HomePatternType._(2, _omitEnumNames ? '' : 'TOP_LEVEL_DIRECTORY');
+  static const HomePatternType CONTAINING_DIRECTORY =
+      HomePatternType._(3, _omitEnumNames ? '' : 'CONTAINING_DIRECTORY');
+  static const HomePatternType HOME_DIRECTORY =
+      HomePatternType._(4, _omitEnumNames ? '' : 'HOME_DIRECTORY');
+  static const HomePatternType MATCHING_FILE_EXTENSION =
+      HomePatternType._(5, _omitEnumNames ? '' : 'MATCHING_FILE_EXTENSION');
+  static const HomePatternType REQUESTED_DIRECTORY_CONTENTS = HomePatternType._(
+      6, _omitEnumNames ? '' : 'REQUESTED_DIRECTORY_CONTENTS');
 
-  static const $core.List<HomePatternType> values = <HomePatternType> [
+  static const $core.List<HomePatternType> values = <HomePatternType>[
     REQUESTED_DIRECTORY,
     REQUESTED_FILE,
     TOP_LEVEL_DIRECTORY,
@@ -81,11 +100,13 @@ class HomePatternType extends $pb.ProtobufEnum {
     REQUESTED_DIRECTORY_CONTENTS,
   ];
 
-  static final $core.Map<$core.int, HomePatternType> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static HomePatternType? valueOf($core.int value) => _byValue[value];
+  static final $core.List<HomePatternType?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 6);
+  static HomePatternType? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const HomePatternType._($core.int v, $core.String n) : super(v, n);
+  const HomePatternType._(super.value, super.name);
 }
 
-
-const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');
+const $core.bool _omitEnumNames =
+    $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pbgrpc.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pbgrpc.dart
@@ -1,13 +1,14 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: apparmor-prompting.proto
-//
-// @dart = 2.12
+// Generated from apparmor-prompting.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;
@@ -23,44 +24,70 @@ export 'apparmor-prompting.pb.dart';
 
 @$pb.GrpcServiceName('apparmor_prompting.AppArmorPrompting')
 class AppArmorPromptingClient extends $grpc.Client {
-  static final _$getCurrentPrompt = $grpc.ClientMethod<$0.Empty, $1.GetCurrentPromptResponse>(
-      '/apparmor_prompting.AppArmorPrompting/GetCurrentPrompt',
-      ($0.Empty value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.GetCurrentPromptResponse.fromBuffer(value));
-  static final _$replyToPrompt = $grpc.ClientMethod<$1.PromptReply, $1.PromptReplyResponse>(
-      '/apparmor_prompting.AppArmorPrompting/ReplyToPrompt',
-      ($1.PromptReply value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.PromptReplyResponse.fromBuffer(value));
-  static final _$resolveHomePatternType = $grpc.ClientMethod<$2.StringValue, $1.ResolveHomePatternTypeResponse>(
-      '/apparmor_prompting.AppArmorPrompting/ResolveHomePatternType',
-      ($2.StringValue value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.ResolveHomePatternTypeResponse.fromBuffer(value));
-  static final _$setLoggingFilter = $grpc.ClientMethod<$2.StringValue, $1.SetLoggingFilterResponse>(
-      '/apparmor_prompting.AppArmorPrompting/SetLoggingFilter',
-      ($2.StringValue value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.SetLoggingFilterResponse.fromBuffer(value));
+  /// The hostname for this service.
+  static const $core.String defaultHost = '';
 
-  AppArmorPromptingClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
-      : super(channel, options: options,
-        interceptors: interceptors);
+  /// OAuth scopes needed for the client.
+  static const $core.List<$core.String> oauthScopes = [
+    '',
+  ];
 
-  $grpc.ResponseFuture<$1.GetCurrentPromptResponse> getCurrentPrompt($0.Empty request, {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$getCurrentPrompt, request, options: options);
+  AppArmorPromptingClient(super.channel, {super.options, super.interceptors});
+
+  $grpc.ResponseStream<$1.GetCurrentPromptResponse> getCurrentPrompt(
+    $0.Empty request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createStreamingCall(
+        _$getCurrentPrompt, $async.Stream.fromIterable([request]),
+        options: options);
   }
 
-  $grpc.ResponseFuture<$1.PromptReplyResponse> replyToPrompt($1.PromptReply request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$1.PromptReplyResponse> replyToPrompt(
+    $1.PromptReply request, {
+    $grpc.CallOptions? options,
+  }) {
     return $createUnaryCall(_$replyToPrompt, request, options: options);
   }
 
-  $grpc.ResponseFuture<$1.ResolveHomePatternTypeResponse> resolveHomePatternType($2.StringValue request, {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$resolveHomePatternType, request, options: options);
+  $grpc.ResponseFuture<$1.ResolveHomePatternTypeResponse>
+      resolveHomePatternType(
+    $2.StringValue request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$resolveHomePatternType, request,
+        options: options);
   }
 
-  $grpc.ResponseFuture<$1.SetLoggingFilterResponse> setLoggingFilter($2.StringValue request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$1.SetLoggingFilterResponse> setLoggingFilter(
+    $2.StringValue request, {
+    $grpc.CallOptions? options,
+  }) {
     return $createUnaryCall(_$setLoggingFilter, request, options: options);
   }
+
+  // method descriptors
+
+  static final _$getCurrentPrompt =
+      $grpc.ClientMethod<$0.Empty, $1.GetCurrentPromptResponse>(
+          '/apparmor_prompting.AppArmorPrompting/GetCurrentPrompt',
+          ($0.Empty value) => value.writeToBuffer(),
+          $1.GetCurrentPromptResponse.fromBuffer);
+  static final _$replyToPrompt =
+      $grpc.ClientMethod<$1.PromptReply, $1.PromptReplyResponse>(
+          '/apparmor_prompting.AppArmorPrompting/ReplyToPrompt',
+          ($1.PromptReply value) => value.writeToBuffer(),
+          $1.PromptReplyResponse.fromBuffer);
+  static final _$resolveHomePatternType =
+      $grpc.ClientMethod<$2.StringValue, $1.ResolveHomePatternTypeResponse>(
+          '/apparmor_prompting.AppArmorPrompting/ResolveHomePatternType',
+          ($2.StringValue value) => value.writeToBuffer(),
+          $1.ResolveHomePatternTypeResponse.fromBuffer);
+  static final _$setLoggingFilter =
+      $grpc.ClientMethod<$2.StringValue, $1.SetLoggingFilterResponse>(
+          '/apparmor_prompting.AppArmorPrompting/SetLoggingFilter',
+          ($2.StringValue value) => value.writeToBuffer(),
+          $1.SetLoggingFilterResponse.fromBuffer);
 }
 
 @$pb.GrpcServiceName('apparmor_prompting.AppArmorPrompting')
@@ -72,7 +99,7 @@ abstract class AppArmorPromptingServiceBase extends $grpc.Service {
         'GetCurrentPrompt',
         getCurrentPrompt_Pre,
         false,
-        false,
+        true,
         ($core.List<$core.int> value) => $0.Empty.fromBuffer(value),
         ($1.GetCurrentPromptResponse value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$1.PromptReply, $1.PromptReplyResponse>(
@@ -82,13 +109,15 @@ abstract class AppArmorPromptingServiceBase extends $grpc.Service {
         false,
         ($core.List<$core.int> value) => $1.PromptReply.fromBuffer(value),
         ($1.PromptReplyResponse value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$2.StringValue, $1.ResolveHomePatternTypeResponse>(
-        'ResolveHomePatternType',
-        resolveHomePatternType_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) => $2.StringValue.fromBuffer(value),
-        ($1.ResolveHomePatternTypeResponse value) => value.writeToBuffer()));
+    $addMethod(
+        $grpc.ServiceMethod<$2.StringValue, $1.ResolveHomePatternTypeResponse>(
+            'ResolveHomePatternType',
+            resolveHomePatternType_Pre,
+            false,
+            false,
+            ($core.List<$core.int> value) => $2.StringValue.fromBuffer(value),
+            ($1.ResolveHomePatternTypeResponse value) =>
+                value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$2.StringValue, $1.SetLoggingFilterResponse>(
         'SetLoggingFilter',
         setLoggingFilter_Pre,
@@ -98,24 +127,35 @@ abstract class AppArmorPromptingServiceBase extends $grpc.Service {
         ($1.SetLoggingFilterResponse value) => value.writeToBuffer()));
   }
 
-  $async.Future<$1.GetCurrentPromptResponse> getCurrentPrompt_Pre($grpc.ServiceCall call, $async.Future<$0.Empty> request) async {
-    return getCurrentPrompt(call, await request);
+  $async.Stream<$1.GetCurrentPromptResponse> getCurrentPrompt_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.Empty> $request) async* {
+    yield* getCurrentPrompt($call, await $request);
   }
 
-  $async.Future<$1.PromptReplyResponse> replyToPrompt_Pre($grpc.ServiceCall call, $async.Future<$1.PromptReply> request) async {
-    return replyToPrompt(call, await request);
+  $async.Stream<$1.GetCurrentPromptResponse> getCurrentPrompt(
+      $grpc.ServiceCall call, $0.Empty request);
+
+  $async.Future<$1.PromptReplyResponse> replyToPrompt_Pre(
+      $grpc.ServiceCall $call, $async.Future<$1.PromptReply> $request) async {
+    return replyToPrompt($call, await $request);
   }
 
-  $async.Future<$1.ResolveHomePatternTypeResponse> resolveHomePatternType_Pre($grpc.ServiceCall call, $async.Future<$2.StringValue> request) async {
-    return resolveHomePatternType(call, await request);
+  $async.Future<$1.PromptReplyResponse> replyToPrompt(
+      $grpc.ServiceCall call, $1.PromptReply request);
+
+  $async.Future<$1.ResolveHomePatternTypeResponse> resolveHomePatternType_Pre(
+      $grpc.ServiceCall $call, $async.Future<$2.StringValue> $request) async {
+    return resolveHomePatternType($call, await $request);
   }
 
-  $async.Future<$1.SetLoggingFilterResponse> setLoggingFilter_Pre($grpc.ServiceCall call, $async.Future<$2.StringValue> request) async {
-    return setLoggingFilter(call, await request);
+  $async.Future<$1.ResolveHomePatternTypeResponse> resolveHomePatternType(
+      $grpc.ServiceCall call, $2.StringValue request);
+
+  $async.Future<$1.SetLoggingFilterResponse> setLoggingFilter_Pre(
+      $grpc.ServiceCall $call, $async.Future<$2.StringValue> $request) async {
+    return setLoggingFilter($call, await $request);
   }
 
-  $async.Future<$1.GetCurrentPromptResponse> getCurrentPrompt($grpc.ServiceCall call, $0.Empty request);
-  $async.Future<$1.PromptReplyResponse> replyToPrompt($grpc.ServiceCall call, $1.PromptReply request);
-  $async.Future<$1.ResolveHomePatternTypeResponse> resolveHomePatternType($grpc.ServiceCall call, $2.StringValue request);
-  $async.Future<$1.SetLoggingFilterResponse> setLoggingFilter($grpc.ServiceCall call, $2.StringValue request);
+  $async.Future<$1.SetLoggingFilterResponse> setLoggingFilter(
+      $grpc.ServiceCall call, $2.StringValue request);
 }

--- a/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pbjson.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pbjson.dart
@@ -1,13 +1,14 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: apparmor-prompting.proto
-//
-// @dart = 2.12
+// Generated from apparmor-prompting.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;
@@ -23,8 +24,8 @@ const Action$json = {
 };
 
 /// Descriptor for `Action`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List actionDescriptor = $convert.base64Decode(
-    'CgZBY3Rpb24SCQoFQUxMT1cQABIICgRERU5ZEAE=');
+final $typed_data.Uint8List actionDescriptor =
+    $convert.base64Decode('CgZBY3Rpb24SCQoFQUxMT1cQABIICgRERU5ZEAE=');
 
 @$core.Deprecated('Use lifespanDescriptor instead')
 const Lifespan$json = {
@@ -80,9 +81,31 @@ const PromptReply$json = {
   '1': 'PromptReply',
   '2': [
     {'1': 'prompt_id', '3': 1, '4': 1, '5': 9, '10': 'promptId'},
-    {'1': 'action', '3': 2, '4': 1, '5': 14, '6': '.apparmor_prompting.Action', '10': 'action'},
-    {'1': 'lifespan', '3': 3, '4': 1, '5': 14, '6': '.apparmor_prompting.Lifespan', '10': 'lifespan'},
-    {'1': 'home_prompt_reply', '3': 4, '4': 1, '5': 11, '6': '.apparmor_prompting.HomePromptReply', '9': 0, '10': 'homePromptReply'},
+    {
+      '1': 'action',
+      '3': 2,
+      '4': 1,
+      '5': 14,
+      '6': '.apparmor_prompting.Action',
+      '10': 'action'
+    },
+    {
+      '1': 'lifespan',
+      '3': 3,
+      '4': 1,
+      '5': 14,
+      '6': '.apparmor_prompting.Lifespan',
+      '10': 'lifespan'
+    },
+    {
+      '1': 'home_prompt_reply',
+      '3': 4,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.HomePromptReply',
+      '9': 0,
+      '10': 'homePromptReply'
+    },
   ],
   '8': [
     {'1': 'prompt_reply'},
@@ -102,17 +125,96 @@ const PromptReplyResponse$json = {
   '1': 'PromptReplyResponse',
   '2': [
     {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
-    {'1': 'success', '3': 2, '4': 1, '5': 11, '6': '.google.protobuf.Empty', '9': 0, '10': 'success'},
-    {'1': 'raw', '3': 3, '4': 1, '5': 11, '6': '.google.protobuf.Empty', '9': 0, '10': 'raw'},
-    {'1': 'prompt_not_found', '3': 4, '4': 1, '5': 11, '6': '.google.protobuf.Empty', '9': 0, '10': 'promptNotFound'},
-    {'1': 'rule_not_found', '3': 5, '4': 1, '5': 11, '6': '.google.protobuf.Empty', '9': 0, '10': 'ruleNotFound'},
-    {'1': 'rule_conflicts', '3': 6, '4': 1, '5': 11, '6': '.apparmor_prompting.PromptReplyResponse.HomeRuleConflicts', '9': 0, '10': 'ruleConflicts'},
-    {'1': 'invalid_permissions', '3': 7, '4': 1, '5': 11, '6': '.apparmor_prompting.PromptReplyResponse.InvalidHomePermissions', '9': 0, '10': 'invalidPermissions'},
-    {'1': 'invalid_path_pattern', '3': 8, '4': 1, '5': 11, '6': '.apparmor_prompting.PromptReplyResponse.InvalidPathPattern', '9': 0, '10': 'invalidPathPattern'},
-    {'1': 'parse_error', '3': 9, '4': 1, '5': 11, '6': '.apparmor_prompting.PromptReplyResponse.ParseError', '9': 0, '10': 'parseError'},
-    {'1': 'unsupported_value', '3': 10, '4': 1, '5': 11, '6': '.apparmor_prompting.PromptReplyResponse.UnsupportedValue', '9': 0, '10': 'unsupportedValue'},
+    {
+      '1': 'success',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Empty',
+      '9': 0,
+      '10': 'success'
+    },
+    {
+      '1': 'raw',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Empty',
+      '9': 0,
+      '10': 'raw'
+    },
+    {
+      '1': 'prompt_not_found',
+      '3': 4,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Empty',
+      '9': 0,
+      '10': 'promptNotFound'
+    },
+    {
+      '1': 'rule_not_found',
+      '3': 5,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Empty',
+      '9': 0,
+      '10': 'ruleNotFound'
+    },
+    {
+      '1': 'rule_conflicts',
+      '3': 6,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.PromptReplyResponse.HomeRuleConflicts',
+      '9': 0,
+      '10': 'ruleConflicts'
+    },
+    {
+      '1': 'invalid_permissions',
+      '3': 7,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.PromptReplyResponse.InvalidHomePermissions',
+      '9': 0,
+      '10': 'invalidPermissions'
+    },
+    {
+      '1': 'invalid_path_pattern',
+      '3': 8,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.PromptReplyResponse.InvalidPathPattern',
+      '9': 0,
+      '10': 'invalidPathPattern'
+    },
+    {
+      '1': 'parse_error',
+      '3': 9,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.PromptReplyResponse.ParseError',
+      '9': 0,
+      '10': 'parseError'
+    },
+    {
+      '1': 'unsupported_value',
+      '3': 10,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.PromptReplyResponse.UnsupportedValue',
+      '9': 0,
+      '10': 'unsupportedValue'
+    },
   ],
-  '3': [PromptReplyResponse_HomeRuleConflicts$json, PromptReplyResponse_HomeRuleConflict$json, PromptReplyResponse_InvalidHomePermissions$json, PromptReplyResponse_InvalidPathPattern$json, PromptReplyResponse_ParseError$json, PromptReplyResponse_UnsupportedValue$json],
+  '3': [
+    PromptReplyResponse_HomeRuleConflicts$json,
+    PromptReplyResponse_HomeRuleConflict$json,
+    PromptReplyResponse_InvalidHomePermissions$json,
+    PromptReplyResponse_InvalidPathPattern$json,
+    PromptReplyResponse_ParseError$json,
+    PromptReplyResponse_UnsupportedValue$json
+  ],
   '8': [
     {'1': 'prompt_reply_type'},
   ],
@@ -122,7 +224,14 @@ const PromptReplyResponse$json = {
 const PromptReplyResponse_HomeRuleConflicts$json = {
   '1': 'HomeRuleConflicts',
   '2': [
-    {'1': 'conflicts', '3': 1, '4': 3, '5': 11, '6': '.apparmor_prompting.PromptReplyResponse.HomeRuleConflict', '10': 'conflicts'},
+    {
+      '1': 'conflicts',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.apparmor_prompting.PromptReplyResponse.HomeRuleConflict',
+      '10': 'conflicts'
+    },
   ],
 };
 
@@ -130,7 +239,14 @@ const PromptReplyResponse_HomeRuleConflicts$json = {
 const PromptReplyResponse_HomeRuleConflict$json = {
   '1': 'HomeRuleConflict',
   '2': [
-    {'1': 'permission', '3': 1, '4': 1, '5': 14, '6': '.apparmor_prompting.HomePermission', '10': 'permission'},
+    {
+      '1': 'permission',
+      '3': 1,
+      '4': 1,
+      '5': 14,
+      '6': '.apparmor_prompting.HomePermission',
+      '10': 'permission'
+    },
     {'1': 'variant', '3': 2, '4': 1, '5': 9, '10': 'variant'},
     {'1': 'conflicting_id', '3': 3, '4': 1, '5': 9, '10': 'conflictingId'},
   ],
@@ -140,8 +256,22 @@ const PromptReplyResponse_HomeRuleConflict$json = {
 const PromptReplyResponse_InvalidHomePermissions$json = {
   '1': 'InvalidHomePermissions',
   '2': [
-    {'1': 'requested', '3': 1, '4': 3, '5': 14, '6': '.apparmor_prompting.HomePermission', '10': 'requested'},
-    {'1': 'replied', '3': 2, '4': 3, '5': 14, '6': '.apparmor_prompting.HomePermission', '10': 'replied'},
+    {
+      '1': 'requested',
+      '3': 1,
+      '4': 3,
+      '5': 14,
+      '6': '.apparmor_prompting.HomePermission',
+      '10': 'requested'
+    },
+    {
+      '1': 'replied',
+      '3': 2,
+      '4': 3,
+      '5': 14,
+      '6': '.apparmor_prompting.HomePermission',
+      '10': 'replied'
+    },
   ],
 };
 
@@ -207,7 +337,15 @@ final $typed_data.Uint8List promptReplyResponseDescriptor = $convert.base64Decod
 const GetCurrentPromptResponse$json = {
   '1': 'GetCurrentPromptResponse',
   '2': [
-    {'1': 'home_prompt', '3': 1, '4': 1, '5': 11, '6': '.apparmor_prompting.HomePrompt', '9': 0, '10': 'homePrompt'},
+    {
+      '1': 'home_prompt',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.HomePrompt',
+      '9': 0,
+      '10': 'homePrompt'
+    },
   ],
   '8': [
     {'1': 'prompt'},
@@ -215,16 +353,24 @@ const GetCurrentPromptResponse$json = {
 };
 
 /// Descriptor for `GetCurrentPromptResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getCurrentPromptResponseDescriptor = $convert.base64Decode(
-    'ChhHZXRDdXJyZW50UHJvbXB0UmVzcG9uc2USQQoLaG9tZV9wcm9tcHQYASABKAsyHi5hcHBhcm'
-    '1vcl9wcm9tcHRpbmcuSG9tZVByb21wdEgAUgpob21lUHJvbXB0QggKBnByb21wdA==');
+final $typed_data.Uint8List getCurrentPromptResponseDescriptor =
+    $convert.base64Decode(
+        'ChhHZXRDdXJyZW50UHJvbXB0UmVzcG9uc2USQQoLaG9tZV9wcm9tcHQYASABKAsyHi5hcHBhcm'
+        '1vcl9wcm9tcHRpbmcuSG9tZVByb21wdEgAUgpob21lUHJvbXB0QggKBnByb21wdA==');
 
 @$core.Deprecated('Use homePromptReplyDescriptor instead')
 const HomePromptReply$json = {
   '1': 'HomePromptReply',
   '2': [
     {'1': 'path_pattern', '3': 1, '4': 1, '5': 9, '10': 'pathPattern'},
-    {'1': 'permissions', '3': 2, '4': 3, '5': 14, '6': '.apparmor_prompting.HomePermission', '10': 'permissions'},
+    {
+      '1': 'permissions',
+      '3': 2,
+      '4': 3,
+      '5': 14,
+      '6': '.apparmor_prompting.HomePermission',
+      '10': 'permissions'
+    },
   ],
 };
 
@@ -238,15 +384,63 @@ final $typed_data.Uint8List homePromptReplyDescriptor = $convert.base64Decode(
 const HomePrompt$json = {
   '1': 'HomePrompt',
   '2': [
-    {'1': 'meta_data', '3': 1, '4': 1, '5': 11, '6': '.apparmor_prompting.MetaData', '10': 'metaData'},
+    {
+      '1': 'meta_data',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.MetaData',
+      '10': 'metaData'
+    },
     {'1': 'requested_path', '3': 2, '4': 1, '5': 9, '10': 'requestedPath'},
     {'1': 'home_dir', '3': 3, '4': 1, '5': 9, '10': 'homeDir'},
-    {'1': 'requested_permissions', '3': 4, '4': 3, '5': 14, '6': '.apparmor_prompting.HomePermission', '10': 'requestedPermissions'},
-    {'1': 'available_permissions', '3': 5, '4': 3, '5': 14, '6': '.apparmor_prompting.HomePermission', '10': 'availablePermissions'},
-    {'1': 'suggested_permissions', '3': 6, '4': 3, '5': 14, '6': '.apparmor_prompting.HomePermission', '10': 'suggestedPermissions'},
-    {'1': 'pattern_options', '3': 7, '4': 3, '5': 11, '6': '.apparmor_prompting.HomePrompt.PatternOption', '10': 'patternOptions'},
-    {'1': 'initial_pattern_option', '3': 8, '4': 1, '5': 5, '10': 'initialPatternOption'},
-    {'1': 'enriched_path_kind', '3': 9, '4': 1, '5': 11, '6': '.apparmor_prompting.EnrichedPathKind', '10': 'enrichedPathKind'},
+    {
+      '1': 'requested_permissions',
+      '3': 4,
+      '4': 3,
+      '5': 14,
+      '6': '.apparmor_prompting.HomePermission',
+      '10': 'requestedPermissions'
+    },
+    {
+      '1': 'available_permissions',
+      '3': 5,
+      '4': 3,
+      '5': 14,
+      '6': '.apparmor_prompting.HomePermission',
+      '10': 'availablePermissions'
+    },
+    {
+      '1': 'suggested_permissions',
+      '3': 6,
+      '4': 3,
+      '5': 14,
+      '6': '.apparmor_prompting.HomePermission',
+      '10': 'suggestedPermissions'
+    },
+    {
+      '1': 'pattern_options',
+      '3': 7,
+      '4': 3,
+      '5': 11,
+      '6': '.apparmor_prompting.HomePrompt.PatternOption',
+      '10': 'patternOptions'
+    },
+    {
+      '1': 'initial_pattern_option',
+      '3': 8,
+      '4': 1,
+      '5': 5,
+      '10': 'initialPatternOption'
+    },
+    {
+      '1': 'enriched_path_kind',
+      '3': 9,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.EnrichedPathKind',
+      '10': 'enrichedPathKind'
+    },
   ],
   '3': [HomePrompt_PatternOption$json],
 };
@@ -255,7 +449,14 @@ const HomePrompt$json = {
 const HomePrompt_PatternOption$json = {
   '1': 'PatternOption',
   '2': [
-    {'1': 'home_pattern_type', '3': 1, '4': 1, '5': 14, '6': '.apparmor_prompting.HomePatternType', '10': 'homePatternType'},
+    {
+      '1': 'home_pattern_type',
+      '3': 1,
+      '4': 1,
+      '5': 14,
+      '6': '.apparmor_prompting.HomePatternType',
+      '10': 'homePatternType'
+    },
     {'1': 'path_pattern', '3': 2, '4': 1, '5': 9, '10': 'pathPattern'},
     {'1': 'show_initially', '3': 3, '4': 1, '5': 8, '10': 'showInitially'},
   ],
@@ -301,15 +502,23 @@ final $typed_data.Uint8List metaDataDescriptor = $convert.base64Decode(
 const ResolveHomePatternTypeResponse$json = {
   '1': 'ResolveHomePatternTypeResponse',
   '2': [
-    {'1': 'home_pattern_type', '3': 1, '4': 1, '5': 14, '6': '.apparmor_prompting.HomePatternType', '10': 'homePatternType'},
+    {
+      '1': 'home_pattern_type',
+      '3': 1,
+      '4': 1,
+      '5': 14,
+      '6': '.apparmor_prompting.HomePatternType',
+      '10': 'homePatternType'
+    },
   ],
 };
 
 /// Descriptor for `ResolveHomePatternTypeResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resolveHomePatternTypeResponseDescriptor = $convert.base64Decode(
-    'Ch5SZXNvbHZlSG9tZVBhdHRlcm5UeXBlUmVzcG9uc2USTwoRaG9tZV9wYXR0ZXJuX3R5cGUYAS'
-    'ABKA4yIy5hcHBhcm1vcl9wcm9tcHRpbmcuSG9tZVBhdHRlcm5UeXBlUg9ob21lUGF0dGVyblR5'
-    'cGU=');
+final $typed_data.Uint8List resolveHomePatternTypeResponseDescriptor =
+    $convert.base64Decode(
+        'Ch5SZXNvbHZlSG9tZVBhdHRlcm5UeXBlUmVzcG9uc2USTwoRaG9tZV9wYXR0ZXJuX3R5cGUYAS'
+        'ABKA4yIy5hcHBhcm1vcl9wcm9tcHRpbmcuSG9tZVBhdHRlcm5UeXBlUg9ob21lUGF0dGVyblR5'
+        'cGU=');
 
 @$core.Deprecated('Use setLoggingFilterResponseDescriptor instead')
 const SetLoggingFilterResponse$json = {
@@ -320,19 +529,68 @@ const SetLoggingFilterResponse$json = {
 };
 
 /// Descriptor for `SetLoggingFilterResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setLoggingFilterResponseDescriptor = $convert.base64Decode(
-    'ChhTZXRMb2dnaW5nRmlsdGVyUmVzcG9uc2USGAoHY3VycmVudBgBIAEoCVIHY3VycmVudA==');
+final $typed_data.Uint8List setLoggingFilterResponseDescriptor =
+    $convert.base64Decode(
+        'ChhTZXRMb2dnaW5nRmlsdGVyUmVzcG9uc2USGAoHY3VycmVudBgBIAEoCVIHY3VycmVudA==');
 
 @$core.Deprecated('Use enrichedPathKindDescriptor instead')
 const EnrichedPathKind$json = {
   '1': 'EnrichedPathKind',
   '2': [
-    {'1': 'home_dir', '3': 1, '4': 1, '5': 11, '6': '.apparmor_prompting.HomeDir', '9': 0, '10': 'homeDir'},
-    {'1': 'top_level_dir', '3': 2, '4': 1, '5': 11, '6': '.apparmor_prompting.TopLevelDir', '9': 0, '10': 'topLevelDir'},
-    {'1': 'sub_dir', '3': 3, '4': 1, '5': 11, '6': '.apparmor_prompting.SubDir', '9': 0, '10': 'subDir'},
-    {'1': 'home_dir_file', '3': 4, '4': 1, '5': 11, '6': '.apparmor_prompting.HomeDirFile', '9': 0, '10': 'homeDirFile'},
-    {'1': 'top_level_dir_file', '3': 5, '4': 1, '5': 11, '6': '.apparmor_prompting.TopLevelDirFile', '9': 0, '10': 'topLevelDirFile'},
-    {'1': 'sub_dir_file', '3': 6, '4': 1, '5': 11, '6': '.apparmor_prompting.SubDirFile', '9': 0, '10': 'subDirFile'},
+    {
+      '1': 'home_dir',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.HomeDir',
+      '9': 0,
+      '10': 'homeDir'
+    },
+    {
+      '1': 'top_level_dir',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.TopLevelDir',
+      '9': 0,
+      '10': 'topLevelDir'
+    },
+    {
+      '1': 'sub_dir',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.SubDir',
+      '9': 0,
+      '10': 'subDir'
+    },
+    {
+      '1': 'home_dir_file',
+      '3': 4,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.HomeDirFile',
+      '9': 0,
+      '10': 'homeDirFile'
+    },
+    {
+      '1': 'top_level_dir_file',
+      '3': 5,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.TopLevelDirFile',
+      '9': 0,
+      '10': 'topLevelDirFile'
+    },
+    {
+      '1': 'sub_dir_file',
+      '3': 6,
+      '4': 1,
+      '5': 11,
+      '6': '.apparmor_prompting.SubDirFile',
+      '9': 0,
+      '10': 'subDirFile'
+    },
   ],
   '8': [
     {'1': 'kind'},
@@ -356,8 +614,8 @@ const HomeDir$json = {
 };
 
 /// Descriptor for `HomeDir`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List homeDirDescriptor = $convert.base64Decode(
-    'CgdIb21lRGly');
+final $typed_data.Uint8List homeDirDescriptor =
+    $convert.base64Decode('CgdIb21lRGly');
 
 @$core.Deprecated('Use topLevelDirDescriptor instead')
 const TopLevelDir$json = {
@@ -368,8 +626,8 @@ const TopLevelDir$json = {
 };
 
 /// Descriptor for `TopLevelDir`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List topLevelDirDescriptor = $convert.base64Decode(
-    'CgtUb3BMZXZlbERpchIYCgdkaXJuYW1lGAEgASgJUgdkaXJuYW1l');
+final $typed_data.Uint8List topLevelDirDescriptor = $convert
+    .base64Decode('CgtUb3BMZXZlbERpchIYCgdkaXJuYW1lGAEgASgJUgdkaXJuYW1l');
 
 @$core.Deprecated('Use subDirDescriptor instead')
 const SubDir$json = {
@@ -377,8 +635,8 @@ const SubDir$json = {
 };
 
 /// Descriptor for `SubDir`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List subDirDescriptor = $convert.base64Decode(
-    'CgZTdWJEaXI=');
+final $typed_data.Uint8List subDirDescriptor =
+    $convert.base64Decode('CgZTdWJEaXI=');
 
 @$core.Deprecated('Use homeDirFileDescriptor instead')
 const HomeDirFile$json = {
@@ -389,8 +647,8 @@ const HomeDirFile$json = {
 };
 
 /// Descriptor for `HomeDirFile`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List homeDirFileDescriptor = $convert.base64Decode(
-    'CgtIb21lRGlyRmlsZRIaCghmaWxlbmFtZRgBIAEoCVIIZmlsZW5hbWU=');
+final $typed_data.Uint8List homeDirFileDescriptor = $convert
+    .base64Decode('CgtIb21lRGlyRmlsZRIaCghmaWxlbmFtZRgBIAEoCVIIZmlsZW5hbWU=');
 
 @$core.Deprecated('Use topLevelDirFileDescriptor instead')
 const TopLevelDirFile$json = {
@@ -412,6 +670,5 @@ const SubDirFile$json = {
 };
 
 /// Descriptor for `SubDirFile`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List subDirFileDescriptor = $convert.base64Decode(
-    'CgpTdWJEaXJGaWxl');
-
+final $typed_data.Uint8List subDirFileDescriptor =
+    $convert.base64Decode('CgpTdWJEaXJGaWxl');

--- a/flutter/packages/prompting_client/lib/src/generated/google/protobuf/empty.pb.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/google/protobuf/empty.pb.dart
@@ -1,56 +1,66 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: google/protobuf/empty.proto
-//
-// @dart = 2.12
+// Generated from google/protobuf/empty.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-///  A generic empty message that you can re-use to avoid defining duplicated
-///  empty messages in your APIs. A typical example is to use it as the request
-///  or the response type of an API method. For instance:
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
 ///
-///      service Foo {
-///        rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-///      }
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
 class Empty extends $pb.GeneratedMessage {
   factory Empty() => create();
-  Empty._() : super();
-  factory Empty.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Empty.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Empty', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  Empty._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Empty.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Empty.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Empty',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Empty clone() => Empty()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)) as Empty;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Empty copyWith(void Function(Empty) updates) =>
+      super.copyWith((message) => updates(message as Empty)) as Empty;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static Empty create() => Empty._();
+  @$core.override
   Empty createEmptyInstance() => create();
   static $pb.PbList<Empty> createRepeated() => $pb.PbList<Empty>();
   @$core.pragma('dart2js:noInline')
-  static Empty getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);
+  static Empty getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);
   static Empty? _defaultInstance;
 }
 
-
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/flutter/packages/prompting_client/lib/src/generated/google/protobuf/empty.pbenum.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/google/protobuf/empty.pbenum.dart
@@ -1,11 +1,11 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: google/protobuf/empty.proto
-//
-// @dart = 2.12
+// Generated from google/protobuf/empty.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names

--- a/flutter/packages/prompting_client/lib/src/generated/google/protobuf/empty.pbjson.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/google/protobuf/empty.pbjson.dart
@@ -1,13 +1,14 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: google/protobuf/empty.proto
-//
-// @dart = 2.12
+// Generated from google/protobuf/empty.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;
@@ -19,6 +20,5 @@ const Empty$json = {
 };
 
 /// Descriptor for `Empty`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List emptyDescriptor = $convert.base64Decode(
-    'CgVFbXB0eQ==');
-
+final $typed_data.Uint8List emptyDescriptor =
+    $convert.base64Decode('CgVFbXB0eQ==');

--- a/flutter/packages/prompting_client/lib/src/generated/google/protobuf/wrappers.pb.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/google/protobuf/wrappers.pb.dart
@@ -1,13 +1,15 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: google/protobuf/wrappers.proto
-//
-// @dart = 2.12
+// Generated from google/protobuf/wrappers.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: implementation_imports, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:core' as $core;
 
@@ -15,492 +17,564 @@ import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 import 'package:protobuf/src/protobuf/mixins/well_known.dart' as $mixin;
 
-///  Wrapper message for `double`.
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
+
+/// Wrapper message for `double`.
 ///
-///  The JSON representation for `DoubleValue` is JSON number.
+/// The JSON representation for `DoubleValue` is JSON number.
 class DoubleValue extends $pb.GeneratedMessage with $mixin.DoubleValueMixin {
   factory DoubleValue({
     $core.double? value,
   }) {
-    final $result = create();
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  DoubleValue._() : super();
-  factory DoubleValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory DoubleValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DoubleValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.DoubleValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.DoubleValueMixin.fromProto3JsonHelper)
+  DoubleValue._();
+
+  factory DoubleValue.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DoubleValue.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'DoubleValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.DoubleValueMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.DoubleValueMixin.fromProto3JsonHelper)
     ..a<$core.double>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OD)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   DoubleValue clone() => DoubleValue()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  DoubleValue copyWith(void Function(DoubleValue) updates) => super.copyWith((message) => updates(message as DoubleValue)) as DoubleValue;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DoubleValue copyWith(void Function(DoubleValue) updates) =>
+      super.copyWith((message) => updates(message as DoubleValue))
+          as DoubleValue;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static DoubleValue create() => DoubleValue._();
+  @$core.override
   DoubleValue createEmptyInstance() => create();
   static $pb.PbList<DoubleValue> createRepeated() => $pb.PbList<DoubleValue>();
   @$core.pragma('dart2js:noInline')
-  static DoubleValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DoubleValue>(create);
+  static DoubleValue getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<DoubleValue>(create);
   static DoubleValue? _defaultInstance;
 
   /// The double value.
   @$pb.TagNumber(1)
   $core.double get value => $_getN(0);
   @$pb.TagNumber(1)
-  set value($core.double v) { $_setDouble(0, v); }
+  set value($core.double value) => $_setDouble(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
-///  Wrapper message for `float`.
+/// Wrapper message for `float`.
 ///
-///  The JSON representation for `FloatValue` is JSON number.
+/// The JSON representation for `FloatValue` is JSON number.
 class FloatValue extends $pb.GeneratedMessage with $mixin.FloatValueMixin {
   factory FloatValue({
     $core.double? value,
   }) {
-    final $result = create();
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  FloatValue._() : super();
-  factory FloatValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory FloatValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'FloatValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.FloatValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.FloatValueMixin.fromProto3JsonHelper)
+  FloatValue._();
+
+  factory FloatValue.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory FloatValue.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'FloatValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.FloatValueMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.FloatValueMixin.fromProto3JsonHelper)
     ..a<$core.double>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OF)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   FloatValue clone() => FloatValue()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  FloatValue copyWith(void Function(FloatValue) updates) => super.copyWith((message) => updates(message as FloatValue)) as FloatValue;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  FloatValue copyWith(void Function(FloatValue) updates) =>
+      super.copyWith((message) => updates(message as FloatValue)) as FloatValue;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static FloatValue create() => FloatValue._();
+  @$core.override
   FloatValue createEmptyInstance() => create();
   static $pb.PbList<FloatValue> createRepeated() => $pb.PbList<FloatValue>();
   @$core.pragma('dart2js:noInline')
-  static FloatValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FloatValue>(create);
+  static FloatValue getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<FloatValue>(create);
   static FloatValue? _defaultInstance;
 
   /// The float value.
   @$pb.TagNumber(1)
   $core.double get value => $_getN(0);
   @$pb.TagNumber(1)
-  set value($core.double v) { $_setFloat(0, v); }
+  set value($core.double value) => $_setFloat(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
-///  Wrapper message for `int64`.
+/// Wrapper message for `int64`.
 ///
-///  The JSON representation for `Int64Value` is JSON string.
+/// The JSON representation for `Int64Value` is JSON string.
 class Int64Value extends $pb.GeneratedMessage with $mixin.Int64ValueMixin {
   factory Int64Value({
     $fixnum.Int64? value,
   }) {
-    final $result = create();
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  Int64Value._() : super();
-  factory Int64Value.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Int64Value.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Int64Value', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.Int64ValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.Int64ValueMixin.fromProto3JsonHelper)
+  Int64Value._();
+
+  factory Int64Value.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Int64Value.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Int64Value',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.Int64ValueMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.Int64ValueMixin.fromProto3JsonHelper)
     ..aInt64(1, _omitFieldNames ? '' : 'value')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Int64Value clone() => Int64Value()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Int64Value copyWith(void Function(Int64Value) updates) => super.copyWith((message) => updates(message as Int64Value)) as Int64Value;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Int64Value copyWith(void Function(Int64Value) updates) =>
+      super.copyWith((message) => updates(message as Int64Value)) as Int64Value;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static Int64Value create() => Int64Value._();
+  @$core.override
   Int64Value createEmptyInstance() => create();
   static $pb.PbList<Int64Value> createRepeated() => $pb.PbList<Int64Value>();
   @$core.pragma('dart2js:noInline')
-  static Int64Value getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Int64Value>(create);
+  static Int64Value getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<Int64Value>(create);
   static Int64Value? _defaultInstance;
 
   /// The int64 value.
   @$pb.TagNumber(1)
   $fixnum.Int64 get value => $_getI64(0);
   @$pb.TagNumber(1)
-  set value($fixnum.Int64 v) { $_setInt64(0, v); }
+  set value($fixnum.Int64 value) => $_setInt64(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
-///  Wrapper message for `uint64`.
+/// Wrapper message for `uint64`.
 ///
-///  The JSON representation for `UInt64Value` is JSON string.
+/// The JSON representation for `UInt64Value` is JSON string.
 class UInt64Value extends $pb.GeneratedMessage with $mixin.UInt64ValueMixin {
   factory UInt64Value({
     $fixnum.Int64? value,
   }) {
-    final $result = create();
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  UInt64Value._() : super();
-  factory UInt64Value.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory UInt64Value.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UInt64Value', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.UInt64ValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.UInt64ValueMixin.fromProto3JsonHelper)
-    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
-    ..hasRequiredFields = false
-  ;
+  UInt64Value._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory UInt64Value.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory UInt64Value.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'UInt64Value',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.UInt64ValueMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.UInt64ValueMixin.fromProto3JsonHelper)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   UInt64Value clone() => UInt64Value()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  UInt64Value copyWith(void Function(UInt64Value) updates) => super.copyWith((message) => updates(message as UInt64Value)) as UInt64Value;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  UInt64Value copyWith(void Function(UInt64Value) updates) =>
+      super.copyWith((message) => updates(message as UInt64Value))
+          as UInt64Value;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static UInt64Value create() => UInt64Value._();
+  @$core.override
   UInt64Value createEmptyInstance() => create();
   static $pb.PbList<UInt64Value> createRepeated() => $pb.PbList<UInt64Value>();
   @$core.pragma('dart2js:noInline')
-  static UInt64Value getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UInt64Value>(create);
+  static UInt64Value getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<UInt64Value>(create);
   static UInt64Value? _defaultInstance;
 
   /// The uint64 value.
   @$pb.TagNumber(1)
   $fixnum.Int64 get value => $_getI64(0);
   @$pb.TagNumber(1)
-  set value($fixnum.Int64 v) { $_setInt64(0, v); }
+  set value($fixnum.Int64 value) => $_setInt64(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
-///  Wrapper message for `int32`.
+/// Wrapper message for `int32`.
 ///
-///  The JSON representation for `Int32Value` is JSON number.
+/// The JSON representation for `Int32Value` is JSON number.
 class Int32Value extends $pb.GeneratedMessage with $mixin.Int32ValueMixin {
   factory Int32Value({
     $core.int? value,
   }) {
-    final $result = create();
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  Int32Value._() : super();
-  factory Int32Value.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Int32Value.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Int32Value', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.Int32ValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.Int32ValueMixin.fromProto3JsonHelper)
+  Int32Value._();
+
+  factory Int32Value.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Int32Value.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Int32Value',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.Int32ValueMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.Int32ValueMixin.fromProto3JsonHelper)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Int32Value clone() => Int32Value()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Int32Value copyWith(void Function(Int32Value) updates) => super.copyWith((message) => updates(message as Int32Value)) as Int32Value;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Int32Value copyWith(void Function(Int32Value) updates) =>
+      super.copyWith((message) => updates(message as Int32Value)) as Int32Value;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static Int32Value create() => Int32Value._();
+  @$core.override
   Int32Value createEmptyInstance() => create();
   static $pb.PbList<Int32Value> createRepeated() => $pb.PbList<Int32Value>();
   @$core.pragma('dart2js:noInline')
-  static Int32Value getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Int32Value>(create);
+  static Int32Value getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<Int32Value>(create);
   static Int32Value? _defaultInstance;
 
   /// The int32 value.
   @$pb.TagNumber(1)
   $core.int get value => $_getIZ(0);
   @$pb.TagNumber(1)
-  set value($core.int v) { $_setSignedInt32(0, v); }
+  set value($core.int value) => $_setSignedInt32(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
-///  Wrapper message for `uint32`.
+/// Wrapper message for `uint32`.
 ///
-///  The JSON representation for `UInt32Value` is JSON number.
+/// The JSON representation for `UInt32Value` is JSON number.
 class UInt32Value extends $pb.GeneratedMessage with $mixin.UInt32ValueMixin {
   factory UInt32Value({
     $core.int? value,
   }) {
-    final $result = create();
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  UInt32Value._() : super();
-  factory UInt32Value.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory UInt32Value.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UInt32Value', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.UInt32ValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.UInt32ValueMixin.fromProto3JsonHelper)
+  UInt32Value._();
+
+  factory UInt32Value.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory UInt32Value.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'UInt32Value',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.UInt32ValueMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.UInt32ValueMixin.fromProto3JsonHelper)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OU3)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   UInt32Value clone() => UInt32Value()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  UInt32Value copyWith(void Function(UInt32Value) updates) => super.copyWith((message) => updates(message as UInt32Value)) as UInt32Value;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  UInt32Value copyWith(void Function(UInt32Value) updates) =>
+      super.copyWith((message) => updates(message as UInt32Value))
+          as UInt32Value;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static UInt32Value create() => UInt32Value._();
+  @$core.override
   UInt32Value createEmptyInstance() => create();
   static $pb.PbList<UInt32Value> createRepeated() => $pb.PbList<UInt32Value>();
   @$core.pragma('dart2js:noInline')
-  static UInt32Value getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UInt32Value>(create);
+  static UInt32Value getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<UInt32Value>(create);
   static UInt32Value? _defaultInstance;
 
   /// The uint32 value.
   @$pb.TagNumber(1)
   $core.int get value => $_getIZ(0);
   @$pb.TagNumber(1)
-  set value($core.int v) { $_setUnsignedInt32(0, v); }
+  set value($core.int value) => $_setUnsignedInt32(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
-///  Wrapper message for `bool`.
+/// Wrapper message for `bool`.
 ///
-///  The JSON representation for `BoolValue` is JSON `true` and `false`.
+/// The JSON representation for `BoolValue` is JSON `true` and `false`.
 class BoolValue extends $pb.GeneratedMessage with $mixin.BoolValueMixin {
   factory BoolValue({
     $core.bool? value,
   }) {
-    final $result = create();
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  BoolValue._() : super();
-  factory BoolValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory BoolValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BoolValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.BoolValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.BoolValueMixin.fromProto3JsonHelper)
+  BoolValue._();
+
+  factory BoolValue.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory BoolValue.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'BoolValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.BoolValueMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.BoolValueMixin.fromProto3JsonHelper)
     ..aOB(1, _omitFieldNames ? '' : 'value')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   BoolValue clone() => BoolValue()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  BoolValue copyWith(void Function(BoolValue) updates) => super.copyWith((message) => updates(message as BoolValue)) as BoolValue;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  BoolValue copyWith(void Function(BoolValue) updates) =>
+      super.copyWith((message) => updates(message as BoolValue)) as BoolValue;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static BoolValue create() => BoolValue._();
+  @$core.override
   BoolValue createEmptyInstance() => create();
   static $pb.PbList<BoolValue> createRepeated() => $pb.PbList<BoolValue>();
   @$core.pragma('dart2js:noInline')
-  static BoolValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BoolValue>(create);
+  static BoolValue getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BoolValue>(create);
   static BoolValue? _defaultInstance;
 
   /// The bool value.
   @$pb.TagNumber(1)
   $core.bool get value => $_getBF(0);
   @$pb.TagNumber(1)
-  set value($core.bool v) { $_setBool(0, v); }
+  set value($core.bool value) => $_setBool(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
-///  Wrapper message for `string`.
+/// Wrapper message for `string`.
 ///
-///  The JSON representation for `StringValue` is JSON string.
+/// The JSON representation for `StringValue` is JSON string.
 class StringValue extends $pb.GeneratedMessage with $mixin.StringValueMixin {
   factory StringValue({
     $core.String? value,
   }) {
-    final $result = create();
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  StringValue._() : super();
-  factory StringValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StringValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StringValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.StringValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.StringValueMixin.fromProto3JsonHelper)
+  StringValue._();
+
+  factory StringValue.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StringValue.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StringValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.StringValueMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.StringValueMixin.fromProto3JsonHelper)
     ..aOS(1, _omitFieldNames ? '' : 'value')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StringValue clone() => StringValue()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StringValue copyWith(void Function(StringValue) updates) => super.copyWith((message) => updates(message as StringValue)) as StringValue;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StringValue copyWith(void Function(StringValue) updates) =>
+      super.copyWith((message) => updates(message as StringValue))
+          as StringValue;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static StringValue create() => StringValue._();
+  @$core.override
   StringValue createEmptyInstance() => create();
   static $pb.PbList<StringValue> createRepeated() => $pb.PbList<StringValue>();
   @$core.pragma('dart2js:noInline')
-  static StringValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StringValue>(create);
+  static StringValue getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<StringValue>(create);
   static StringValue? _defaultInstance;
 
   /// The string value.
   @$pb.TagNumber(1)
   $core.String get value => $_getSZ(0);
   @$pb.TagNumber(1)
-  set value($core.String v) { $_setString(0, v); }
+  set value($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
-///  Wrapper message for `bytes`.
+/// Wrapper message for `bytes`.
 ///
-///  The JSON representation for `BytesValue` is JSON string.
+/// The JSON representation for `BytesValue` is JSON string.
 class BytesValue extends $pb.GeneratedMessage with $mixin.BytesValueMixin {
   factory BytesValue({
     $core.List<$core.int>? value,
   }) {
-    final $result = create();
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  BytesValue._() : super();
-  factory BytesValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory BytesValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BytesValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.BytesValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.BytesValueMixin.fromProto3JsonHelper)
-    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+  BytesValue._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory BytesValue.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory BytesValue.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'BytesValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.BytesValueMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.BytesValueMixin.fromProto3JsonHelper)
+    ..a<$core.List<$core.int>>(
+        1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   BytesValue clone() => BytesValue()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  BytesValue copyWith(void Function(BytesValue) updates) => super.copyWith((message) => updates(message as BytesValue)) as BytesValue;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  BytesValue copyWith(void Function(BytesValue) updates) =>
+      super.copyWith((message) => updates(message as BytesValue)) as BytesValue;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static BytesValue create() => BytesValue._();
+  @$core.override
   BytesValue createEmptyInstance() => create();
   static $pb.PbList<BytesValue> createRepeated() => $pb.PbList<BytesValue>();
   @$core.pragma('dart2js:noInline')
-  static BytesValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BytesValue>(create);
+  static BytesValue getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<BytesValue>(create);
   static BytesValue? _defaultInstance;
 
   /// The bytes value.
   @$pb.TagNumber(1)
   $core.List<$core.int> get value => $_getN(0);
   @$pb.TagNumber(1)
-  set value($core.List<$core.int> v) { $_setBytes(0, v); }
+  set value($core.List<$core.int> value) => $_setBytes(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
-
-const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/flutter/packages/prompting_client/lib/src/generated/google/protobuf/wrappers.pbenum.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/google/protobuf/wrappers.pbenum.dart
@@ -1,11 +1,11 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: google/protobuf/wrappers.proto
-//
-// @dart = 2.12
+// Generated from google/protobuf/wrappers.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names

--- a/flutter/packages/prompting_client/lib/src/generated/google/protobuf/wrappers.pbjson.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/google/protobuf/wrappers.pbjson.dart
@@ -1,13 +1,14 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: google/protobuf/wrappers.proto
-//
-// @dart = 2.12
+// Generated from google/protobuf/wrappers.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;
@@ -22,8 +23,8 @@ const DoubleValue$json = {
 };
 
 /// Descriptor for `DoubleValue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List doubleValueDescriptor = $convert.base64Decode(
-    'CgtEb3VibGVWYWx1ZRIUCgV2YWx1ZRgBIAEoAVIFdmFsdWU=');
+final $typed_data.Uint8List doubleValueDescriptor =
+    $convert.base64Decode('CgtEb3VibGVWYWx1ZRIUCgV2YWx1ZRgBIAEoAVIFdmFsdWU=');
 
 @$core.Deprecated('Use floatValueDescriptor instead')
 const FloatValue$json = {
@@ -34,8 +35,8 @@ const FloatValue$json = {
 };
 
 /// Descriptor for `FloatValue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List floatValueDescriptor = $convert.base64Decode(
-    'CgpGbG9hdFZhbHVlEhQKBXZhbHVlGAEgASgCUgV2YWx1ZQ==');
+final $typed_data.Uint8List floatValueDescriptor =
+    $convert.base64Decode('CgpGbG9hdFZhbHVlEhQKBXZhbHVlGAEgASgCUgV2YWx1ZQ==');
 
 @$core.Deprecated('Use int64ValueDescriptor instead')
 const Int64Value$json = {
@@ -46,8 +47,8 @@ const Int64Value$json = {
 };
 
 /// Descriptor for `Int64Value`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List int64ValueDescriptor = $convert.base64Decode(
-    'CgpJbnQ2NFZhbHVlEhQKBXZhbHVlGAEgASgDUgV2YWx1ZQ==');
+final $typed_data.Uint8List int64ValueDescriptor =
+    $convert.base64Decode('CgpJbnQ2NFZhbHVlEhQKBXZhbHVlGAEgASgDUgV2YWx1ZQ==');
 
 @$core.Deprecated('Use uInt64ValueDescriptor instead')
 const UInt64Value$json = {
@@ -58,8 +59,8 @@ const UInt64Value$json = {
 };
 
 /// Descriptor for `UInt64Value`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List uInt64ValueDescriptor = $convert.base64Decode(
-    'CgtVSW50NjRWYWx1ZRIUCgV2YWx1ZRgBIAEoBFIFdmFsdWU=');
+final $typed_data.Uint8List uInt64ValueDescriptor =
+    $convert.base64Decode('CgtVSW50NjRWYWx1ZRIUCgV2YWx1ZRgBIAEoBFIFdmFsdWU=');
 
 @$core.Deprecated('Use int32ValueDescriptor instead')
 const Int32Value$json = {
@@ -70,8 +71,8 @@ const Int32Value$json = {
 };
 
 /// Descriptor for `Int32Value`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List int32ValueDescriptor = $convert.base64Decode(
-    'CgpJbnQzMlZhbHVlEhQKBXZhbHVlGAEgASgFUgV2YWx1ZQ==');
+final $typed_data.Uint8List int32ValueDescriptor =
+    $convert.base64Decode('CgpJbnQzMlZhbHVlEhQKBXZhbHVlGAEgASgFUgV2YWx1ZQ==');
 
 @$core.Deprecated('Use uInt32ValueDescriptor instead')
 const UInt32Value$json = {
@@ -82,8 +83,8 @@ const UInt32Value$json = {
 };
 
 /// Descriptor for `UInt32Value`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List uInt32ValueDescriptor = $convert.base64Decode(
-    'CgtVSW50MzJWYWx1ZRIUCgV2YWx1ZRgBIAEoDVIFdmFsdWU=');
+final $typed_data.Uint8List uInt32ValueDescriptor =
+    $convert.base64Decode('CgtVSW50MzJWYWx1ZRIUCgV2YWx1ZRgBIAEoDVIFdmFsdWU=');
 
 @$core.Deprecated('Use boolValueDescriptor instead')
 const BoolValue$json = {
@@ -94,8 +95,8 @@ const BoolValue$json = {
 };
 
 /// Descriptor for `BoolValue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List boolValueDescriptor = $convert.base64Decode(
-    'CglCb29sVmFsdWUSFAoFdmFsdWUYASABKAhSBXZhbHVl');
+final $typed_data.Uint8List boolValueDescriptor =
+    $convert.base64Decode('CglCb29sVmFsdWUSFAoFdmFsdWUYASABKAhSBXZhbHVl');
 
 @$core.Deprecated('Use stringValueDescriptor instead')
 const StringValue$json = {
@@ -106,8 +107,8 @@ const StringValue$json = {
 };
 
 /// Descriptor for `StringValue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stringValueDescriptor = $convert.base64Decode(
-    'CgtTdHJpbmdWYWx1ZRIUCgV2YWx1ZRgBIAEoCVIFdmFsdWU=');
+final $typed_data.Uint8List stringValueDescriptor =
+    $convert.base64Decode('CgtTdHJpbmdWYWx1ZRIUCgV2YWx1ZRgBIAEoCVIFdmFsdWU=');
 
 @$core.Deprecated('Use bytesValueDescriptor instead')
 const BytesValue$json = {
@@ -118,6 +119,5 @@ const BytesValue$json = {
 };
 
 /// Descriptor for `BytesValue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List bytesValueDescriptor = $convert.base64Decode(
-    'CgpCeXRlc1ZhbHVlEhQKBXZhbHVlGAEgASgMUgV2YWx1ZQ==');
-
+final $typed_data.Uint8List bytesValueDescriptor =
+    $convert.base64Decode('CgpCeXRlc1ZhbHVlEhQKBXZhbHVlGAEgASgMUgV2YWx1ZQ==');

--- a/flutter/packages/prompting_client/lib/src/prompting_client.dart
+++ b/flutter/packages/prompting_client/lib/src/prompting_client.dart
@@ -25,9 +25,8 @@ class PromptingClient {
 
   final pb.AppArmorPromptingClient _client;
 
-  Future<PromptDetails> getCurrentPrompt() => _client
-      .getCurrentPrompt(Empty())
-      .then(PrompteDetailsConversion.fromProto);
+  Stream<PromptDetails> getCurrentPrompt() =>
+      _client.getCurrentPrompt(Empty()).map(PrompteDetailsConversion.fromProto);
 
   Future<PromptReplyResponse> replyToPrompt(PromptReply reply) => _client
       .replyToPrompt(reply.toProto())

--- a/flutter/packages/prompting_client/pubspec.yaml
+++ b/flutter/packages/prompting_client/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   freezed_annotation: ^2.4.4
   grpc: ^4.0.0
   json_annotation: ^4.9.0
-  protobuf: ^3.1.0
+  protobuf: ^4.0.0
 
 dev_dependencies:
   build_runner: ^2.4.9

--- a/prompting-client/Cargo.lock
+++ b/prompting-client/Cargo.lock
@@ -977,6 +977,7 @@ dependencies = [
  "strum",
  "thiserror",
  "tokio",
+ "tokio-context",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -1400,6 +1401,15 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-context"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf0b8394dd5ca9a1b726c629390154c19222dfd7467a4b56f1ced90adee3958"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]

--- a/prompting-client/Cargo.toml
+++ b/prompting-client/Cargo.toml
@@ -46,6 +46,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-journald = "0.3.0"
 cached = { version = "0.54.0", features = ["async"] }
+tokio-context = "0.1.3"
 
 [dev-dependencies]
 serial_test = "3.1.1"

--- a/prompting-client/src/bin/daemon.rs
+++ b/prompting-client/src/bin/daemon.rs
@@ -15,8 +15,6 @@ async fn main() -> Result<()> {
         .with_filter_reloading();
 
     let reload_handle = builder.reload_handle();
-    // let journald_layer = tracing_journald::layer().expect("unable to open journald socket");
-    // let subscriber = builder.finish().with(journald_layer);
     let subscriber = builder.finish();
 
     set_global_default(subscriber).expect("unable to set a global tracing subscriber");

--- a/prompting-client/src/bin/daemon.rs
+++ b/prompting-client/src/bin/daemon.rs
@@ -5,7 +5,7 @@ use prompting_client::{
 };
 use std::{env, io::stdout};
 use tracing::subscriber::set_global_default;
-use tracing_subscriber::{layer::SubscriberExt, FmtSubscriber};
+use tracing_subscriber::FmtSubscriber;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/prompting-client/src/bin/daemon.rs
+++ b/prompting-client/src/bin/daemon.rs
@@ -15,8 +15,9 @@ async fn main() -> Result<()> {
         .with_filter_reloading();
 
     let reload_handle = builder.reload_handle();
-    let journald_layer = tracing_journald::layer().expect("unable to open journald socket");
-    let subscriber = builder.finish().with(journald_layer);
+    // let journald_layer = tracing_journald::layer().expect("unable to open journald socket");
+    // let subscriber = builder.finish().with(journald_layer);
+    let subscriber = builder.finish();
 
     set_global_default(subscriber).expect("unable to set a global tracing subscriber");
 

--- a/prompting-client/src/daemon/mod.rs
+++ b/prompting-client/src/daemon/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     Result, SOCKET_ENV_VAR,
 };
 use serde::{Deserialize, Serialize};
-use std::{env, fs, sync::Arc};
+use std::{env, fmt::Debug, fs, sync::Arc};
 use tokio::sync::mpsc::unbounded_channel;
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::{async_trait, transport::Server};
@@ -19,7 +19,7 @@ use server::new_server_and_listener;
 use worker::Worker;
 
 #[async_trait]
-pub trait ReplyToPrompt: Send + Sync + 'static {
+pub trait ReplyToPrompt: Debug + Send + Sync + 'static {
     async fn reply(&self, id: &PromptId, reply: TypedPromptReply) -> crate::Result<Vec<PromptId>>;
 }
 

--- a/prompting-client/src/daemon/server.rs
+++ b/prompting-client/src/daemon/server.rs
@@ -562,11 +562,13 @@ mod tests {
         let mut client =
             setup_server_and_client(mock_client, active_prompt.clone(), tx_actioned_prompts).await;
 
-        let mut stream = client
-            .get_current_prompt(Request::new(()))
-            .await
-            .unwrap()
-            .into_inner();
+        let response = client.get_current_prompt(Request::new(())).await;
+        if expected.is_none() {
+            assert!(response.is_err());
+            return;
+        }
+
+        let mut stream = response.unwrap().into_inner();
 
         let resp = stream
             .message()

--- a/prompting-client/src/daemon/server.rs
+++ b/prompting-client/src/daemon/server.rs
@@ -342,7 +342,7 @@ mod tests {
     };
     use uuid::Uuid;
 
-    #[derive(Clone)]
+    #[derive(Debug, Clone)]
     struct MockClient {
         want_err: bool,
         expected_reply: Option<TypedPromptReply>,

--- a/prompting-client/src/daemon/server.rs
+++ b/prompting-client/src/daemon/server.rs
@@ -577,7 +577,7 @@ mod tests {
         assert_eq!(resp, expected);
 
         if expected.is_some() {
-            active_prompt.drop();
+            active_prompt.drop_prompt();
         }
         let next = stream.message().await.unwrap();
         assert_eq!(next, None);

--- a/prompting-client/src/daemon/server.rs
+++ b/prompting-client/src/daemon/server.rs
@@ -127,7 +127,7 @@ where
 
             None => {
                 warn!("got request for current prompt but there is no active prompt");
-                None
+                return Err(Status::internal("active prompt not found"));
             }
         };
 
@@ -135,12 +135,8 @@ where
             Some(mut ctx) => {
                 tokio::spawn(async move {
                     debug!("spawning stream");
-                    if tx
-                        .send(Ok(GetCurrentPromptResponse { prompt }))
-                        .await
-                        .is_err()
-                    {
-                        error!("could not send prompt");
+                    if let Err(e) = tx.send(Ok(GetCurrentPromptResponse { prompt })).await {
+                        error!("could not send prompt: {}", e);
                     }
                     ctx.done().await;
                     debug!("closing stream");
@@ -148,6 +144,7 @@ where
             }
             None => {
                 warn!("got request for current prompt but there is no context");
+                return Err(Status::internal("context not found"));
             }
         };
 

--- a/prompting-client/src/daemon/server.rs
+++ b/prompting-client/src/daemon/server.rs
@@ -124,6 +124,19 @@ where
             }
         };
 
+        match self.active_prompt.get_context() {
+            Some(mut ctx) => {
+                tokio::spawn(async move {
+                    debug!("spawning stream");
+                    ctx.done().await;
+                    debug!("closing stream");
+                });
+            }
+            None => {
+                warn!("got request for current prompt but there is no context");
+            }
+        };
+
         Ok(Response::new(GetCurrentPromptResponse { prompt }))
     }
 

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -106,7 +106,7 @@ pub struct FlutterUi {
 
 impl SpawnUi for FlutterUi {
     type Handle = DialogProcess;
-    fn spawn(&mut self, args: &[&str]) -> Result<Self::Handle> {
+    fn spawn(&mut self, args: &[&str]) -> Result<DialogProcess> {
         Ok(DialogProcess(Command::new(&self.cmd).args(args).spawn()?))
     }
 }
@@ -683,7 +683,7 @@ mod tests {
 
     impl SpawnUi for TestUi {
         type Handle = TestDialogHandle;
-        fn spawn(&mut self, _: &[&str]) -> Result<Self::Handle> {
+        fn spawn(&mut self, _: &[&str]) -> Result<TestDialogHandle> {
             debug!("spawning test ui");
             let reply = self.replies.remove(0);
             let tx = self.tx.clone();

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -7,6 +7,7 @@ use crate::{
 use std::{
     collections::VecDeque,
     env,
+    fmt::Debug,
     process::ExitStatus,
     sync::{Arc, Mutex},
     time::Duration,
@@ -31,12 +32,19 @@ enum Recv {
     ChannelClosed,
 }
 
+#[derive(Debug)]
 pub struct RefActivePrompt(Arc<Mutex<Option<ActivePrompt>>>);
 
 pub struct ActivePrompt {
     pub(crate) typed_ui_input: TypedUiInput,
     pub(crate) enriched_prompt: EnrichedPrompt,
     pub(crate) ui_handle: Option<Handle>,
+}
+
+impl Debug for ActivePrompt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "some active prompt")
+    }
 }
 
 impl RefActivePrompt {
@@ -73,10 +81,11 @@ impl Clone for RefActivePrompt {
     }
 }
 
-pub trait DialogHandle {
+pub trait DialogHandle: Debug {
     async fn wait(&mut self) -> Result<ExitStatus>;
 }
 
+#[derive(Debug)]
 pub struct DialogProcess(Child);
 
 impl DialogHandle for DialogProcess {
@@ -85,11 +94,12 @@ impl DialogHandle for DialogProcess {
     }
 }
 
-pub trait SpawnUi {
+pub trait SpawnUi: Debug {
     type Handle;
     fn spawn(&mut self, args: &[&str]) -> Result<Self::Handle>;
 }
 
+#[derive(Debug)]
 pub struct FlutterUi {
     cmd: String,
 }
@@ -101,6 +111,7 @@ impl SpawnUi for FlutterUi {
     }
 }
 
+#[derive(Debug)]
 pub struct Worker<S, R, D>
 where
     S: SpawnUi,
@@ -442,6 +453,7 @@ mod tests {
     };
     use tonic::async_trait;
 
+    #[derive(Debug)]
     struct StubClient;
 
     #[async_trait]
@@ -661,6 +673,7 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
     struct TestUi {
         replies: Vec<Reply>,
         tx: UnboundedSender<ActionedPrompt>,
@@ -692,6 +705,7 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
     struct TestDialogHandle {
         reply: Reply,
         tx: UnboundedSender<ActionedPrompt>,

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -801,7 +801,7 @@ mod tests {
         // for the home interface
         env::set_var("SNAP_REAL_HOME", "/home/ubuntu");
 
-        for update in updates {
+        for update in updates.clone() {
             let _ = tx_prompts.send(update);
         }
 
@@ -811,7 +811,9 @@ mod tests {
         });
 
         // wait for the Test UI to signal that all prompts have been handled
-        rx_done.await.expect("done");
+        if !updates.is_empty() {
+            rx_done.await.expect("done");
+        }
 
         // drop the channel to stop the worker
         drop(tx_prompts);

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -54,7 +54,7 @@ impl RefActivePrompt {
     }
 
     #[cfg(test)]
-    pub fn drop(&mut self) {
+    pub fn drop_prompt(&mut self) {
         self.0.lock().unwrap().take();
     }
 

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -429,14 +429,10 @@ where
 mod tests {
     use super::*;
     use crate::snapd_client::{
-        interfaces::home::{HomeConstraints, HomeReplyConstraints},
-        Action, Lifespan, Prompt, PromptReply, TypedPrompt, TypedPromptReply,
+        interfaces::home::HomeConstraints, Prompt, TypedPrompt, TypedPromptReply,
     };
     use simple_test_case::test_case;
-    use std::{
-        env,
-        sync::{Arc, Mutex},
-    };
+    use std::env;
     use tokio::{
         sync::mpsc::{unbounded_channel, UnboundedSender},
         time::sleep,

--- a/prompting-client/src/lib.rs
+++ b/prompting-client/src/lib.rs
@@ -26,7 +26,7 @@ use snapd_client::SnapdError;
 
 pub(crate) const SNAP_NAME: &str = "prompting-client";
 pub const SOCKET_ENV_VAR: &str = "PROMPTING_CLIENT_SOCKET";
-pub const DEFAULT_LOG_LEVEL: &str = "debug";
+pub const DEFAULT_LOG_LEVEL: &str = "info";
 
 pub fn log_filter(filter: &str) -> String {
     format!("{filter},hyper=error,h2=error")

--- a/prompting-client/src/lib.rs
+++ b/prompting-client/src/lib.rs
@@ -26,7 +26,7 @@ use snapd_client::SnapdError;
 
 pub(crate) const SNAP_NAME: &str = "prompting-client";
 pub const SOCKET_ENV_VAR: &str = "PROMPTING_CLIENT_SOCKET";
-pub const DEFAULT_LOG_LEVEL: &str = "info";
+pub const DEFAULT_LOG_LEVEL: &str = "debug";
 
 pub fn log_filter(filter: &str) -> String {
     format!("{filter},hyper=error,h2=error")

--- a/prompting-client/src/protos/apparmor_prompting.rs
+++ b/prompting-client/src/protos/apparmor_prompting.rs
@@ -440,7 +440,7 @@ pub mod app_armor_prompting_client {
             &mut self,
             request: impl tonic::IntoRequest<()>,
         ) -> std::result::Result<
-            tonic::Response<super::GetCurrentPromptResponse>,
+            tonic::Response<tonic::codec::Streaming<super::GetCurrentPromptResponse>>,
             tonic::Status,
         > {
             self.inner
@@ -463,7 +463,7 @@ pub mod app_armor_prompting_client {
                         "GetCurrentPrompt",
                     ),
                 );
-            self.inner.unary(req, path, codec).await
+            self.inner.server_streaming(req, path, codec).await
         }
         pub async fn reply_to_prompt(
             &mut self,
@@ -567,11 +567,20 @@ pub mod app_armor_prompting_server {
     /// Generated trait containing gRPC methods that should be implemented for use with AppArmorPromptingServer.
     #[async_trait]
     pub trait AppArmorPrompting: std::marker::Send + std::marker::Sync + 'static {
+        /// Server streaming response type for the GetCurrentPrompt method.
+        type GetCurrentPromptStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<
+                    super::GetCurrentPromptResponse,
+                    tonic::Status,
+                >,
+            >
+            + std::marker::Send
+            + 'static;
         async fn get_current_prompt(
             &self,
             request: tonic::Request<()>,
         ) -> std::result::Result<
-            tonic::Response<super::GetCurrentPromptResponse>,
+            tonic::Response<Self::GetCurrentPromptStream>,
             tonic::Status,
         >;
         async fn reply_to_prompt(
@@ -675,11 +684,12 @@ pub mod app_armor_prompting_server {
                 "/apparmor_prompting.AppArmorPrompting/GetCurrentPrompt" => {
                     #[allow(non_camel_case_types)]
                     struct GetCurrentPromptSvc<T: AppArmorPrompting>(pub Arc<T>);
-                    impl<T: AppArmorPrompting> tonic::server::UnaryService<()>
+                    impl<T: AppArmorPrompting> tonic::server::ServerStreamingService<()>
                     for GetCurrentPromptSvc<T> {
                         type Response = super::GetCurrentPromptResponse;
+                        type ResponseStream = T::GetCurrentPromptStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
+                            tonic::Response<Self::ResponseStream>,
                             tonic::Status,
                         >;
                         fn call(&mut self, request: tonic::Request<()>) -> Self::Future {
@@ -711,7 +721,7 @@ pub mod app_armor_prompting_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.unary(method, req).await;
+                        let res = grpc.server_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)

--- a/protos/apparmor-prompting.proto
+++ b/protos/apparmor-prompting.proto
@@ -6,7 +6,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 
 service AppArmorPrompting {
-    rpc GetCurrentPrompt (google.protobuf.Empty) returns (GetCurrentPromptResponse);
+    rpc GetCurrentPrompt (google.protobuf.Empty) returns (stream GetCurrentPromptResponse);
     rpc ReplyToPrompt (PromptReply) returns (PromptReplyResponse);
     rpc ResolveHomePatternType (google.protobuf.StringValue) returns (ResolveHomePatternTypeResponse);
     rpc SetLoggingFilter (google.protobuf.StringValue) returns (SetLoggingFilterResponse);


### PR DESCRIPTION
This makes the prompting-client continue pulling and processing updates while a prompt is shown. If an update renders the active prompt obsolete the UI is automatically closed.

Key changes:
* `worker::step` doesn't block until the prompt UI subprocess terminates anymore, but instead listens for both prompt updates and the process termination in a `tokio::select!` statement.
* the gRPC server now returns a stream of `GetCurrentPromptResponse`s - closing the stream indicates to the UI that the prompt has been dropped and that the UI should quit.

~I'm still working on adjusting the tests and adding new ones.~

Internal spec: UD101
UDENG-7538