### PR TITLE
fix: reduce snap build container size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ local-install-client:
 	rm -rf flutter_packages/prompting_client_ui/build ; \
 	OLD=$(wildcard $(SNAP_NAME)_*) ; \
 	rm $$OLD ; \
-	snapcraft ; \
+	snapcraft pack ; \
 	FILE_NAME=$$(ls | grep -E '$(SNAP_NAME)_' | head -n1) ; \
 	echo ":: Installing $(SNAP_NAME)..." ; \
 	snap install --dangerous $$FILE_NAME ; \

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ ensure-client-in-vm:
 		rm -rf flutter_packages/prompting_client_ui/build ; \
 		OLD=$(wildcard $(SNAP_NAME)_*) ; \
 		[ -n "$$OLD" ] && rm $$OLD ; \
-		snapcraft ; \
+		snapcraft pack ; \
 		FILE_NAME=$$(ls | grep -E '$(SNAP_NAME)_' | head -n1) ; \
 		echo ":: Installing $(SNAP_NAME) in $(VM_NAME)..." ; \
 		[ -n "$$OLD" ] && lxc exec $(VM_NAME) -- rm /home/ubuntu/$$OLD ; \
@@ -112,7 +112,7 @@ ensure-test-snap:
 	@if ! lxc exec $(VM_NAME) -- snap list | grep $(TEST_SNAP_NAME) > /dev/null ; then \
 		echo ":: Building $(TEST_SNAP_NAME) via snapcraft..." ; \
 		cd testing-snap ; \
-		snapcraft ; \
+		snapcraft pack ; \
 		echo ":: Installing $(TEST_SNAP_NAME) in $(VM_NAME)..." ; \
 		lxc file push $(TEST_SNAP_NAME)_0.1_amd64.snap $(VM_NAME)/home/ubuntu/ ; \
 		lxc exec $(VM_NAME) -- snap install --dangerous /home/ubuntu/$(TEST_SNAP_NAME)_0.1_amd64.snap ; \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,6 +79,7 @@ parts:
       cp $CRAFT_PROJECT_DIR/prompting-client/build.rs $CRAFT_PART_SRC/ 
     override-build: |
       set -e
+      rustup default stable
       mkdir -p $(dirname $CRAFT_PART_SRC)/protos
       cp $CRAFT_PROJECT_DIR/protos/* $(dirname $CRAFT_PART_SRC)/protos/
       craftctl default

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,6 +71,12 @@ parts:
   prompting-client:
     plugin: rust
     source: prompting-client
+    override-pull: |
+      mkdir -p $CRAFT_PART_SRC
+      cp -r $CRAFT_PROJECT_DIR/prompting-client/src $CRAFT_PART_SRC/
+      cp $CRAFT_PROJECT_DIR/prompting-client/Cargo.toml $CRAFT_PART_SRC/
+      cp $CRAFT_PROJECT_DIR/prompting-client/Cargo.lock $CRAFT_PART_SRC/
+      cp $CRAFT_PROJECT_DIR/prompting-client/build.rs $CRAFT_PART_SRC/ 
     override-build: |
       set -e
       mkdir -p $(dirname $CRAFT_PART_SRC)/protos
@@ -86,6 +92,12 @@ parts:
     after: [fvm]
     source: .
     plugin: nil
+    override-pull: |
+      mkdir -p $CRAFT_PART_SRC
+      cp $CRAFT_PROJECT_DIR/melos.yaml $CRAFT_PART_SRC/ 
+      cp $CRAFT_PROJECT_DIR/pubspec.yaml $CRAFT_PART_SRC/      
+      cp $CRAFT_PROJECT_DIR/.fvmrc $CRAFT_PART_SRC/
+      cp -r $CRAFT_PROJECT_DIR/flutter $CRAFT_PART_SRC/
     override-build: |
       set -eux
       fvm install
@@ -101,6 +113,6 @@ parts:
 
   desktop-files:
     plugin: dump
-    source: .
+    source: snap/gui
     organize:
-      snap/gui/prompting-client.desktop: usr/share/applications/prompting-client-daemon.desktop
+      prompting-client.desktop: usr/share/applications/prompting-client-daemon.desktop

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,7 +66,7 @@ parts:
       - unzip
       - xz-utils
       - zip
-    override-prime: ''
+    override-prime: ""
 
   prompting-client:
     plugin: rust
@@ -76,7 +76,7 @@ parts:
       cp -r $CRAFT_PROJECT_DIR/prompting-client/src $CRAFT_PART_SRC/
       cp $CRAFT_PROJECT_DIR/prompting-client/Cargo.toml $CRAFT_PART_SRC/
       cp $CRAFT_PROJECT_DIR/prompting-client/Cargo.lock $CRAFT_PART_SRC/
-      cp $CRAFT_PROJECT_DIR/prompting-client/build.rs $CRAFT_PART_SRC/ 
+      cp $CRAFT_PROJECT_DIR/prompting-client/build.rs $CRAFT_PART_SRC/
     override-build: |
       set -e
       rustup default stable
@@ -86,7 +86,7 @@ parts:
     build-packages:
       - libssl-dev
       - pkg-config
-      - protobuf-compiler      
+      - protobuf-compiler
       - libprotobuf-dev
 
   prompting-client-ui:
@@ -95,8 +95,8 @@ parts:
     plugin: nil
     override-pull: |
       mkdir -p $CRAFT_PART_SRC
-      cp $CRAFT_PROJECT_DIR/melos.yaml $CRAFT_PART_SRC/ 
-      cp $CRAFT_PROJECT_DIR/pubspec.yaml $CRAFT_PART_SRC/      
+      cp $CRAFT_PROJECT_DIR/melos.yaml $CRAFT_PART_SRC/
+      cp $CRAFT_PROJECT_DIR/pubspec.yaml $CRAFT_PART_SRC/
       cp $CRAFT_PROJECT_DIR/.fvmrc $CRAFT_PART_SRC/
       cp -r $CRAFT_PROJECT_DIR/flutter $CRAFT_PART_SRC/
     override-build: |


### PR DESCRIPTION
This reduces the build context size during snap builds by implementing selective file copying instead of copying entire directories. Added `override-pull` sections to manually copy only the required files for each part, which significantly reduces memory usage and build times