### PR TITLE
feat: uncomment session lifespan code now that it is supported in snapd

### DIFF
--- a/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
+++ b/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
@@ -308,8 +308,7 @@ class LifespanToggle extends ConsumerWidget {
       title: l10n.promptLifespanTitle,
       options: const [
         Lifespan.forever,
-        // TODO: re-enable support for session lifetimes once this is working in snapd
-        // Lifespan.session,
+        Lifespan.session,
         Lifespan.single,
       ],
       optionTitle: (lifespan) => lifespan.localize(l10n),

--- a/prompting-client/src/snapd_client/prompt.rs
+++ b/prompting-client/src/snapd_client/prompt.rs
@@ -178,7 +178,7 @@ pub enum Action {
 pub enum Lifespan {
     #[default]
     Single,
-    Session, // part of the snapd API but not currently in use
+    Session,
     Forever,
     Timespan, // supported in snapd but not currently used in the UI
 }

--- a/prompting-client/tests/integration.rs
+++ b/prompting-client/tests/integration.rs
@@ -144,8 +144,8 @@ async fn happy_path_read_single(
     Ok(())
 }
 
-//#[test_case(Action::Allow, Lifespan::Session; "allow session")]
-//#[test_case(Action::Deny, Lifespan::Session; "deny session")]
+#[test_case(Action::Allow, Lifespan::Session; "allow session")]
+#[test_case(Action::Deny, Lifespan::Session; "deny session")]
 #[test_case(Action::Allow, Lifespan::Timespan; "allow timespan")]
 #[test_case(Action::Allow, Lifespan::Forever; "allow forever")]
 #[test_case(Action::Deny, Lifespan::Timespan; "deny timespan")]


### PR DESCRIPTION
The `session` lifespan is now supported in snapd. This change simply uncomments the implementation on the prompting client side to expose the feature.

# UI as currently implemented:
## Flutter prompt
<img width="567" height="597" alt="Screenshot From 2025-09-02 13-38-29" src="https://github.com/user-attachments/assets/9b8fdbf3-03d9-4c1d-a56b-4c1bbbf2f545" />

## Security Center
<img width="861" height="661" alt="image" src="https://github.com/user-attachments/assets/60730226-be02-4c92-b108-5c2d4154768d" />
