### PR TITLE
feat: replace allow once default with allow until logout in prompt

### DIFF
--- a/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_en.arb
@@ -31,6 +31,8 @@
     "@promptActionOptionDeny": {},
     "promptActionOptionDenyOnce": "Deny once",
     "@promptActionOptionDenyOnce": {},
+    "promptActionOptionAllowUntilLogout": "Allow until logout",
+    "@promptActionOptionAllowUntilLogout": {},
     "promptActionTitle": "Action",
     "@promptActionTitle": {},
     "promptLifespanOptionForever": "Always",

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations.dart
@@ -287,6 +287,12 @@ abstract class AppLocalizations {
   /// **'Deny once'**
   String get promptActionOptionDenyOnce;
 
+  /// No description provided for @promptActionOptionAllowUntilLogout.
+  ///
+  /// In en, this message translates to:
+  /// **'Allow until logout'**
+  String get promptActionOptionAllowUntilLogout;
+
   /// No description provided for @promptActionTitle.
   ///
   /// In en, this message translates to:

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_am.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_am.dart
@@ -37,6 +37,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ar.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ar.dart
@@ -37,6 +37,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_be.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_be.dart
@@ -37,6 +37,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_bg.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_bg.dart
@@ -37,6 +37,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_bn.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_bn.dart
@@ -37,6 +37,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_bo.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_bo.dart
@@ -37,6 +37,9 @@ class AppLocalizationsBo extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_bs.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_bs.dart
@@ -37,6 +37,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ca.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ca.dart
@@ -37,6 +37,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_cs.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_cs.dart
@@ -37,6 +37,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Jednou zamítnout';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Činnost';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_cy.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_cy.dart
@@ -37,6 +37,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_da.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_da.dart
@@ -37,6 +37,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Nægt denne gang';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Handling';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_de.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_de.dart
@@ -37,6 +37,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Einmal verweigern';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Aktion';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_dz.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_dz.dart
@@ -37,6 +37,9 @@ class AppLocalizationsDz extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_el.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_el.dart
@@ -37,6 +37,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_en.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_en.dart
@@ -37,6 +37,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_eo.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_eo.dart
@@ -37,6 +37,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Malpermesi unu fojon';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Ago';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_es.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_es.dart
@@ -37,6 +37,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Denegar una vez';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Acción';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_et.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_et.dart
@@ -37,6 +37,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Keela üks kord';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Tegevus';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_eu.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_eu.dart
@@ -37,6 +37,9 @@ class AppLocalizationsEu extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_fa.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_fa.dart
@@ -37,6 +37,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'رد کردن برای یک بار';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'کنش';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_fi.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_fi.dart
@@ -37,6 +37,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Estä kerran';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Toiminto';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_fr.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_fr.dart
@@ -37,6 +37,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Refuser une seule fois';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ga.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ga.dart
@@ -37,6 +37,9 @@ class AppLocalizationsGa extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Séanadh uair amháin';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Gníomh';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_gl.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_gl.dart
@@ -37,6 +37,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_gu.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_gu.dart
@@ -37,6 +37,9 @@ class AppLocalizationsGu extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_he.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_he.dart
@@ -37,6 +37,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'לדחות חד־פעמית';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'פעולה';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_hi.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_hi.dart
@@ -37,6 +37,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_hr.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_hr.dart
@@ -37,6 +37,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_hu.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_hu.dart
@@ -37,6 +37,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Tiltás egyszer';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Művelet';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_id.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_id.dart
@@ -37,6 +37,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Tolak sekali';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Aksi';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_is.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_is.dart
@@ -37,6 +37,9 @@ class AppLocalizationsIs extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_it.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_it.dart
@@ -37,6 +37,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ja.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ja.dart
@@ -37,6 +37,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get promptActionOptionDenyOnce => '一度だけ拒否';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'アクション';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ka.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ka.dart
@@ -37,6 +37,9 @@ class AppLocalizationsKa extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'ერთხელ აკრძალვა';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'ქმედება';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_kk.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_kk.dart
@@ -37,6 +37,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_km.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_km.dart
@@ -37,6 +37,9 @@ class AppLocalizationsKm extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_kn.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_kn.dart
@@ -37,6 +37,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ko.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ko.dart
@@ -37,6 +37,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get promptActionOptionDenyOnce => '이번에만 거부';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => '동작';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ku.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ku.dart
@@ -37,6 +37,9 @@ class AppLocalizationsKu extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_lo.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_lo.dart
@@ -37,6 +37,9 @@ class AppLocalizationsLo extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_lt.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_lt.dart
@@ -37,6 +37,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Drausti tik šįkart';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Veiksmas';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_lv.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_lv.dart
@@ -37,6 +37,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_mk.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_mk.dart
@@ -37,6 +37,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ml.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ml.dart
@@ -37,6 +37,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_mr.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_mr.dart
@@ -37,6 +37,9 @@ class AppLocalizationsMr extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_my.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_my.dart
@@ -37,6 +37,9 @@ class AppLocalizationsMy extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_nb.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_nb.dart
@@ -37,6 +37,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Nekt én gang';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Handling';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ne.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ne.dart
@@ -37,6 +37,9 @@ class AppLocalizationsNe extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_nl.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_nl.dart
@@ -37,6 +37,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Eenmaal weigeren';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Actie';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_nn.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_nn.dart
@@ -37,6 +37,9 @@ class AppLocalizationsNn extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_oc.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_oc.dart
@@ -37,6 +37,9 @@ class AppLocalizationsOc extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Refusar un còp';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Accion';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_pa.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_pa.dart
@@ -37,6 +37,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_pl.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_pl.dart
@@ -37,6 +37,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Odmów raz';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Działanie';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_pt.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_pt.dart
@@ -37,6 +37,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ro.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ro.dart
@@ -37,6 +37,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ru.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ru.dart
@@ -37,6 +37,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Отказать один раз';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Действие';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_se.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_se.dart
@@ -37,6 +37,9 @@ class AppLocalizationsSe extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_si.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_si.dart
@@ -37,6 +37,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'ක්‍රියාමාර්ගය';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_sk.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_sk.dart
@@ -37,6 +37,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Raz odmietnuť';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Akcia';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_sl.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_sl.dart
@@ -37,6 +37,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_sq.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_sq.dart
@@ -37,6 +37,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_sr.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_sr.dart
@@ -37,6 +37,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Одбиј једном';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Акција';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_sv.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_sv.dart
@@ -37,6 +37,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Neka en gång';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Åtgärd';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ta.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ta.dart
@@ -37,6 +37,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'ஒரு முறை மறுக்கவும்';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'செயல்';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_te.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_te.dart
@@ -37,6 +37,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_tg.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_tg.dart
@@ -37,6 +37,9 @@ class AppLocalizationsTg extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_th.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_th.dart
@@ -37,6 +37,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_tl.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_tl.dart
@@ -37,6 +37,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_tr.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_tr.dart
@@ -37,6 +37,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ug.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_ug.dart
@@ -37,6 +37,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_uk.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_uk.dart
@@ -37,6 +37,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Відмовити один раз';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Дія';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_vi.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_vi.dart
@@ -37,6 +37,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get promptActionOptionDenyOnce => 'Deny once';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => 'Action';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_zh.dart
+++ b/flutter/apps/prompting_client_ui/lib/l10n/app_localizations_zh.dart
@@ -37,6 +37,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get promptActionOptionDenyOnce => '拒绝一次';
 
   @override
+  String get promptActionOptionAllowUntilLogout => 'Allow until logout';
+
+  @override
   String get promptActionTitle => '动作';
 
   @override

--- a/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
+++ b/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
@@ -217,7 +217,7 @@ class ActionButtons extends ConsumerWidget {
           ]
         : const [
             ActionButton(action: Action.allow, lifespan: Lifespan.forever),
-            ActionButton(action: Action.allow, lifespan: Lifespan.single),
+            ActionButton(action: Action.allow, lifespan: Lifespan.session),
             ActionButton(action: Action.deny, lifespan: Lifespan.single),
           ];
     return Column(
@@ -266,6 +266,8 @@ class ActionButton extends ConsumerWidget {
           (Action.allow, Lifespan.forever) =>
             l10n.promptActionOptionAllowAlways,
           (Action.allow, Lifespan.single) => l10n.promptActionOptionAllowOnce,
+          (Action.allow, Lifespan.session) =>
+            l10n.promptActionOptionAllowUntilLogout,
           (Action.deny, Lifespan.single) => l10n.promptActionOptionDenyOnce,
           (final action, final Lifespan lifespan) =>
             '${action.localize(l10n)} (${lifespan.name})',

--- a/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
+++ b/flutter/apps/prompting_client_ui/test/home/home_prompt_page_test.dart
@@ -505,11 +505,11 @@ void main() {
         ),
       ),
       (
-        name: 'allow once',
-        label: (l10) => l10.promptActionOptionAllowOnce,
+        name: 'allow until logout',
+        label: (l10) => l10.promptActionOptionAllowUntilLogout,
         expectedReply: replyTemplate.copyWith(
           action: Action.allow,
-          lifespan: Lifespan.single,
+          lifespan: Lifespan.session,
         ),
       ),
       (


### PR DESCRIPTION
Following up on #244, this swaps the `Allow once` default prompt replay with the `Allow until logout` option. 
[Figma designs](https://www.figma.com/design/10xVr0m8efJh043Ff6SY4G/25.04-Permission-prompting--AppArmor----Ubuntu-Desktop?node-id=3442-20359&t=wJ02jDhMLfsl2Fi2-0)

## Screenshot
<img width="539" height="394" alt="Screenshot From 2025-09-03 14-11-41" src="https://github.com/user-attachments/assets/a5d806bb-ccb6-46be-a287-b06f52c5d912" />
