### PR TITLE
refactor: align-left policy for `camera` and `home` interfaces

### DIFF
--- a/prompting-client/src/snapd_client/interfaces/camera.rs
+++ b/prompting-client/src/snapd_client/interfaces/camera.rs
@@ -28,18 +28,19 @@ impl PromptReply<CameraInterface> {
     /// This method will error if the requested permissions are not available on the parent
     /// [Prompt].
     pub fn try_with_custom_permissions(mut self, permissions: Vec<String>) -> Result<Self> {
-        if permissions
+        if !permissions
             .iter()
             .all(|p| self.constraints.available_permissions.contains(p))
         {
-            self.constraints.permissions = permissions;
-            Ok(self)
-        } else {
-            Err(Error::InvalidCustomPermissions {
+            return Err(Error::InvalidCustomPermissions {
                 requested: permissions,
                 available: self.constraints.available_permissions,
-            })
+            });
         }
+
+        self.constraints.permissions = permissions;
+
+        Ok(self)
     }
 }
 

--- a/prompting-client/src/snapd_client/interfaces/home.rs
+++ b/prompting-client/src/snapd_client/interfaces/home.rs
@@ -49,18 +49,19 @@ impl PromptReply<HomeInterface> {
     /// This method will error if the requested permissions are not available on the parent
     /// [Prompt].
     pub fn try_with_custom_permissions(mut self, permissions: Vec<String>) -> Result<Self> {
-        if permissions
+        if !permissions
             .iter()
             .all(|p| self.constraints.available_permissions.contains(p))
         {
-            self.constraints.permissions = permissions;
-            Ok(self)
-        } else {
-            Err(Error::InvalidCustomPermissions {
+            return Err(Error::InvalidCustomPermissions {
                 requested: permissions,
                 available: self.constraints.available_permissions,
-            })
+            });
         }
+
+        self.constraints.permissions = permissions;
+
+        Ok(self)
     }
 }
 


### PR DESCRIPTION
Mini refactor to comply to our align-left policy, see https://github.com/canonical/prompting-client/pull/251#discussion_r2341488380