### PR TITLE
feat: feature flagged `auto-reply` to prompt 

### DIFF
--- a/prompting-client/Cargo.toml
+++ b/prompting-client/Cargo.toml
@@ -4,12 +4,14 @@ version = "0.1.0"
 edition = "2021"
 default-run = "prompting-client-echo"
 
-[features]
-dry-run = []
-
 [profile.release]
 strip = true
 lto = true
+
+[features]
+dry-run = []
+time_debugging = []
+auto_answer = ["time_debugging"]
 
 [[bin]]
 name = "prompting-client-scripted"

--- a/prompting-client/Cargo.toml
+++ b/prompting-client/Cargo.toml
@@ -11,7 +11,7 @@ lto = true
 [features]
 dry-run = []
 time_debugging = []
-auto_answer = ["time_debugging"]
+auto_reply = ["time_debugging"]
 
 [[bin]]
 name = "prompting-client-scripted"

--- a/prompting-client/Cargo.toml
+++ b/prompting-client/Cargo.toml
@@ -10,8 +10,8 @@ lto = true
 
 [features]
 dry-run = []
-time_debugging = []
-auto_reply = ["time_debugging"]
+time-debugging = []
+auto-reply = ["time-debugging"]
 
 [[bin]]
 name = "prompting-client-scripted"
@@ -33,7 +33,11 @@ path = "src/bin/set_log_level.rs"
 chrono = "0.4.38"
 clap = { version = "4.5.4", features = ["derive"] }
 http-body-util = "0.1.1"
-hyper-util = { version = "0.1.4", features = ["http1", "tokio", "client-legacy"] }
+hyper-util = { version = "0.1.4", features = [
+    "http1",
+    "tokio",
+    "client-legacy",
+] }
 hyper = { version = "1.3.1", features = ["client", "http1"] }
 prost = "0.13.1"
 prost-types = "0.13.1"
@@ -43,7 +47,15 @@ serde = { version = "1.0.202", features = ["derive"] }
 strum = { version = "0.27.0", features = ["derive"] }
 thiserror = "1.0.61"
 tokio-stream = "0.1.15"
-tokio = { version = "1.43.1", features = ["fs", "io-util", "macros", "net", "process", "signal", "rt-multi-thread"] }
+tokio = { version = "1.43.1", features = [
+    "fs",
+    "io-util",
+    "macros",
+    "net",
+    "process",
+    "signal",
+    "rt-multi-thread",
+] }
 tonic = "0.13.1"
 tonic-reflection = "0.13.1"
 tower = "0.5.2"

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -1,10 +1,14 @@
 //! This is our main worker task for processing prompts from snapd and driving the UI.
+#![cfg_attr(feature = "auto_reply", allow(unreachable_code))]
+
 use crate::{
     daemon::{ActionedPrompt, EnrichedPrompt, PromptUpdate, ReplyToPrompt},
     snapd_client::{Cgroup, PromptId, SnapdSocketClient, TypedUiInput},
     Result,
 };
 use futures::{stream::FuturesUnordered, FutureExt};
+#[cfg(feature = "auto_reply")]
+use std::sync::OnceLock;
 use std::{
     collections::{HashMap, VecDeque},
     env,
@@ -343,6 +347,28 @@ where
                 .clone()
         };
         let expected_id = enriched_prompt.prompt.id().clone();
+
+        #[cfg(feature = "auto_reply")]
+        {
+            static REPLY: OnceLock<String> = OnceLock::new();
+
+            let reply = REPLY.get_or_init(|| {
+                let env_var = env::var("PROMPTING_CLIENT_AUTO_REPLY")
+                    .unwrap_or_else(|_| "DENY_ONCE".to_string());
+                debug!("PROMPTING: auto_reply env value: {:?}", env_var);
+
+                env_var
+            });
+
+            let reply = match reply.as_str() {
+                "ALLOW_ONCE" => enriched_prompt.prompt.into_allow_once(),
+                "ALLOW_FOREVER" => enriched_prompt.prompt.into_allow_forever(),
+                _ => enriched_prompt.prompt.into_deny_once(),
+            };
+            self.client.reply(&expected_id, reply).await?;
+
+            return Ok(());
+        }
 
         loop {
             match self.wait_for_expected_prompt(&expected_id).await {

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -1,6 +1,6 @@
 //! This is our main worker task for processing prompts from snapd and driving the UI.
 
-#![cfg_attr(feature = "auto_reply", allow(unreachable_code))]
+#![cfg_attr(feature = "auto-reply", allow(unreachable_code))]
 #![cfg_attr(feature = "dry-run", allow(unused_variables))]
 
 use crate::{
@@ -9,8 +9,6 @@ use crate::{
     Result,
 };
 use futures::{stream::FuturesUnordered, FutureExt};
-#[cfg(feature = "auto_reply")]
-use std::sync::OnceLock;
 use std::{
     collections::{HashMap, VecDeque},
     env,
@@ -347,14 +345,16 @@ where
         };
         let expected_id = enriched_prompt.prompt.id().clone();
 
-        #[cfg(feature = "auto_reply")]
+        #[cfg(feature = "auto-reply")]
         {
+            use std::sync::OnceLock;
+
             static REPLY: OnceLock<String> = OnceLock::new();
 
             let reply = REPLY.get_or_init(|| {
                 let env_var = env::var("PROMPTING_CLIENT_AUTO_REPLY")
                     .unwrap_or_else(|_| "DENY_ONCE".to_string());
-                debug!("PROMPTING: auto_reply env value: {:?}", env_var);
+                debug!("PROMPTING: auto-reply env value: {:?}", env_var);
 
                 env_var
             });

--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -1,5 +1,7 @@
 //! This is our main worker task for processing prompts from snapd and driving the UI.
+
 #![cfg_attr(feature = "auto_reply", allow(unreachable_code))]
+#![cfg_attr(feature = "dry-run", allow(unused_variables))]
 
 use crate::{
     daemon::{ActionedPrompt, EnrichedPrompt, PromptUpdate, ReplyToPrompt},
@@ -148,9 +150,6 @@ impl Worker<FlutterUi, SnapdSocketClient, DialogProcess> {
         client: SnapdSocketClient,
     ) -> Self {
         let cmd = {
-            // The #[allow(unused_variables)] attribute is necessary here because, when the "dry-run" feature is enabled,
-            // the `cmd` variable is not used in all code paths, which would otherwise cause a warning.
-            #[allow(unused_variables)]
             let cmd = if let Ok(snap) = env::var("SNAP") {
                 format!("{snap}/bin/prompting_client_ui")
             } else {

--- a/prompting-client/src/snapd_client/interfaces/mod.rs
+++ b/prompting-client/src/snapd_client/interfaces/mod.rs
@@ -187,6 +187,28 @@ impl TypedPrompt {
         }
     }
 
+    pub fn into_allow_once(self) -> TypedPromptReply {
+        match self {
+            Self::Camera(p) => CameraInterface::prompt_to_reply(p, Action::Allow).into(),
+            Self::Home(p) => HomeInterface::prompt_to_reply(p, Action::Allow).into(),
+            Self::Microphone(p) => MicrophoneInterface::prompt_to_reply(p, Action::Allow).into(),
+        }
+    }
+
+    pub fn into_allow_forever(self) -> TypedPromptReply {
+        match self {
+            Self::Camera(p) => CameraInterface::prompt_to_reply(p, Action::Allow)
+                .for_forever()
+                .into(),
+            Self::Home(p) => HomeInterface::prompt_to_reply(p, Action::Allow)
+                .for_forever()
+                .into(),
+            Self::Microphone(p) => MicrophoneInterface::prompt_to_reply(p, Action::Allow)
+                .for_forever()
+                .into(),
+        }
+    }
+
     pub fn id(&self) -> &PromptId {
         match self {
             Self::Camera(p) => &p.id,

--- a/prompting-client/src/snapd_client/mod.rs
+++ b/prompting-client/src/snapd_client/mod.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "dry-run", allow(unused_variables))]
+
 use crate::{
     exit_with,
     snapd_client::{prompt::RawPrompt, response::parse_response},
@@ -121,9 +123,7 @@ impl SnapdSocketClient {
                 .unwrap();
             info!(?id, ?now, "pulling prompt details from snapd");
         }
-        // The #[allow(unused_variables)] attribute is necessary here because, when the "dry-run" feature is enabled,
-        // the `socket` variable is not used in all code paths, which would otherwise cause a warning.
-        #[allow(unused_variables)]
+
         let socket = if env::var("SNAP_NAME").is_ok() {
             if UnixStream::connect(SNAPD_ABSTRACT_SNAP_SOCKET)
                 .await

--- a/prompting-client/src/snapd_client/mod.rs
+++ b/prompting-client/src/snapd_client/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 use chrono::{DateTime, SecondsFormat, Utc};
 use hyper::Uri;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{collections::HashMap, env, fmt::Debug, str::FromStr};
+use std::{collections::HashMap, env, str::FromStr};
 use tokio::net::UnixStream;
 use tracing::{debug, error, info, warn};
 

--- a/prompting-client/src/snapd_client/mod.rs
+++ b/prompting-client/src/snapd_client/mod.rs
@@ -113,7 +113,7 @@ impl SnapdSocketClient {
     }
 
     pub async fn new_with_notices_after(dt: DateTime<Utc>) -> Self {
-        #[cfg(feature = "time_debugging")]
+        #[cfg(feature = "time-debugging")]
         {
             use std::time::SystemTime;
 
@@ -238,7 +238,7 @@ where
 
     /// Pull details for all pending prompts from snapd
     pub async fn all_pending_prompt_details(&self) -> Result<Vec<TypedPrompt>> {
-        #[cfg(feature = "time_debugging")]
+        #[cfg(feature = "time-debugging")]
         debug!(
             "PROMPTING: before getting all raw prompts from snapd @ {:?}",
             std::time::Instant::now()
@@ -247,7 +247,7 @@ where
         let raw_prompts: Vec<RawPrompt> =
             self.client.get_json("interfaces/requests/prompts").await?;
 
-        #[cfg(feature = "time_debugging")]
+        #[cfg(feature = "time-debugging")]
         debug!(
             "PROMPTING: after getting all raw prompts from snapd @ {:?}",
             std::time::Instant::now()
@@ -258,7 +258,7 @@ where
 
     /// Pull details for a specific prompt from snapd
     pub async fn prompt_details(&self, id: &PromptId) -> Result<TypedPrompt> {
-        #[cfg(feature = "time_debugging")]
+        #[cfg(feature = "time-debugging")]
         debug!(
             ?id,
             "PROMPTING: before pulling prompt details from snapd @ {:?}",
@@ -270,7 +270,7 @@ where
             .get_json(&format!("interfaces/requests/prompts/{}", id.0))
             .await?;
 
-        #[cfg(feature = "time_debugging")]
+        #[cfg(feature = "time-debugging")]
         debug!(
             ?id,
             "PROMPTING: after pulling prompt details from snapd @ {:?}",
@@ -286,7 +286,7 @@ where
         id: &PromptId,
         reply: TypedPromptReply,
     ) -> Result<Vec<PromptId>> {
-        #[cfg(feature = "time_debugging")]
+        #[cfg(feature = "time-debugging")]
         debug!(
             ?id,
             "PROMPTING: before replying to snapd @ {:?}",
@@ -298,7 +298,7 @@ where
             .post_json(&format!("interfaces/requests/prompts/{}", id.0), reply)
             .await?;
 
-        #[cfg(feature = "time_debugging")]
+        #[cfg(feature = "time-debugging")]
         debug!(
             ?id,
             "PROMPTING: after replying to snapd @ {:?}",


### PR DESCRIPTION
Add `auto-reply` feature flag to support benchmarking automation.

The original implementation is on [autoreply-and-time-debugging](https://github.com/canonical/prompting-client/tree/autoreply-and-time-debugging) branch

---

UDENG-7913