### PR TITLE
feat: fetch snap icons from snapd and display them in prompts

### DIFF
--- a/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
+++ b/flutter/apps/prompting_client_ui/lib/pages/home/home_prompt_page.dart
@@ -25,18 +25,41 @@ class HomePromptPage extends ConsumerWidget {
           .select((m) => m.visiblePatternOptions.isNotEmpty),
     );
     final error = ref.watch(homePromptDataModelProvider.select((m) => m.error));
+    final snapIcon = ref.watch(
+      homePromptDataModelProvider.select((m) => m.details.metaData.snapIcon),
+    );
 
-    return Column(
+    return Row(
+      mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Header(),
-        if (hasVisibleOptions) ...[const Divider(), const PatternOptions()],
-        if (error != null && showMoreOptions) _ErrorBox(error),
-        const Permissions(),
-        if (showMoreOptions) const LifespanToggle(),
-        if (error != null && !showMoreOptions) _ErrorBox(error),
-        const ActionButtons(),
-      ].withSpacing(20),
+        if (snapIcon != null)
+          Padding(
+            padding: const EdgeInsets.only(right: 18),
+            child: Image.memory(
+              snapIcon,
+              width: 48,
+              height: 48,
+            ),
+          ),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Header(),
+              if (hasVisibleOptions) ...[
+                const Divider(),
+                const PatternOptions(),
+              ],
+              if (error != null && showMoreOptions) _ErrorBox(error),
+              const Permissions(),
+              if (showMoreOptions) const LifespanToggle(),
+              if (error != null && !showMoreOptions) _ErrorBox(error),
+              const ActionButtons(),
+            ].withSpacing(20),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/flutter/apps/prompting_client_ui/test/test_prompts/test_home_prompt_details.json
+++ b/flutter/apps/prompting_client_ui/test/test_prompts/test_home_prompt_details.json
@@ -5,7 +5,8 @@
         "snapName": "firefox",
         "updatedAt": "2024-07-13T10:57:28.34963269+02:00",
         "storeUrl": "snap://firefox",
-        "publisher": "Mozilla"
+        "publisher": "Mozilla",
+        "snapIcon": "/snap/firefox/current/default256.png"
     },
     "requestedPath": "/home/user/Downloads/Minotaur/minotaur-13293232.jpeg",
     "homeDir": "/home/user",

--- a/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pb.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pb.dart
@@ -1513,6 +1513,7 @@ class MetaData extends $pb.GeneratedMessage {
     $core.String? storeUrl,
     $core.String? publisher,
     $core.String? updatedAt,
+    $core.List<$core.int>? snapIcon,
   }) {
     final result = create();
     if (promptId != null) result.promptId = promptId;
@@ -1520,6 +1521,7 @@ class MetaData extends $pb.GeneratedMessage {
     if (storeUrl != null) result.storeUrl = storeUrl;
     if (publisher != null) result.publisher = publisher;
     if (updatedAt != null) result.updatedAt = updatedAt;
+    if (snapIcon != null) result.snapIcon = snapIcon;
     return result;
   }
 
@@ -1542,6 +1544,8 @@ class MetaData extends $pb.GeneratedMessage {
     ..aOS(3, _omitFieldNames ? '' : 'storeUrl')
     ..aOS(4, _omitFieldNames ? '' : 'publisher')
     ..aOS(5, _omitFieldNames ? '' : 'updatedAt')
+    ..a<$core.List<$core.int>>(
+        6, _omitFieldNames ? '' : 'snapIcon', $pb.PbFieldType.OY)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -1607,6 +1611,15 @@ class MetaData extends $pb.GeneratedMessage {
   $core.bool hasUpdatedAt() => $_has(4);
   @$pb.TagNumber(5)
   void clearUpdatedAt() => $_clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get snapIcon => $_getN(5);
+  @$pb.TagNumber(6)
+  set snapIcon($core.List<$core.int> value) => $_setBytes(5, value);
+  @$pb.TagNumber(6)
+  $core.bool hasSnapIcon() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearSnapIcon() => $_clearField(6);
 }
 
 class ResolveHomePatternTypeResponse extends $pb.GeneratedMessage {

--- a/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pbjson.dart
+++ b/flutter/packages/prompting_client/lib/src/generated/apparmor-prompting.pbjson.dart
@@ -622,6 +622,18 @@ const MetaData$json = {
     {'1': 'store_url', '3': 3, '4': 1, '5': 9, '10': 'storeUrl'},
     {'1': 'publisher', '3': 4, '4': 1, '5': 9, '10': 'publisher'},
     {'1': 'updated_at', '3': 5, '4': 1, '5': 9, '10': 'updatedAt'},
+    {
+      '1': 'snap_icon',
+      '3': 6,
+      '4': 1,
+      '5': 12,
+      '9': 0,
+      '10': 'snapIcon',
+      '17': true
+    },
+  ],
+  '8': [
+    {'1': '_snap_icon'},
   ],
 };
 
@@ -629,7 +641,8 @@ const MetaData$json = {
 final $typed_data.Uint8List metaDataDescriptor = $convert.base64Decode(
     'CghNZXRhRGF0YRIbCglwcm9tcHRfaWQYASABKAlSCHByb21wdElkEhsKCXNuYXBfbmFtZRgCIA'
     'EoCVIIc25hcE5hbWUSGwoJc3RvcmVfdXJsGAMgASgJUghzdG9yZVVybBIcCglwdWJsaXNoZXIY'
-    'BCABKAlSCXB1Ymxpc2hlchIdCgp1cGRhdGVkX2F0GAUgASgJUgl1cGRhdGVkQXQ=');
+    'BCABKAlSCXB1Ymxpc2hlchIdCgp1cGRhdGVkX2F0GAUgASgJUgl1cGRhdGVkQXQSIAoJc25hcF'
+    '9pY29uGAYgASgMSABSCHNuYXBJY29uiAEBQgwKCl9zbmFwX2ljb24=');
 
 @$core.Deprecated('Use resolveHomePatternTypeResponseDescriptor instead')
 const ResolveHomePatternTypeResponse$json = {

--- a/flutter/packages/prompting_client/lib/src/prompting_client.dart
+++ b/flutter/packages/prompting_client/lib/src/prompting_client.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:grpc/grpc.dart';
@@ -80,6 +81,9 @@ extension MetaDataConversion on MetaData {
         storeUrl: metaData.storeUrl,
         publisher: metaData.publisher,
         updatedAt: DateTime.tryParse(metaData.updatedAt),
+        snapIcon: metaData.hasSnapIcon()
+            ? Uint8List.fromList(metaData.snapIcon)
+            : null,
       );
 }
 

--- a/flutter/packages/prompting_client/lib/src/prompting_models.dart
+++ b/flutter/packages/prompting_client/lib/src/prompting_models.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'prompting_models.freezed.dart';
@@ -33,10 +36,23 @@ class MetaData with _$MetaData {
     DateTime? updatedAt,
     String? storeUrl,
     String? publisher,
+    @BytesConverter() Uint8List? snapIcon,
   }) = _MetaData;
 
   factory MetaData.fromJson(Map<String, dynamic> json) =>
       _$MetaDataFromJson(json);
+}
+
+/// Used to 'deserialize' an icon from an image file in tests.
+class BytesConverter implements JsonConverter<Uint8List, String> {
+  const BytesConverter();
+
+  @override
+  Uint8List fromJson(String json) => File(json).readAsBytesSync();
+
+  @override
+  String toJson(Uint8List object) =>
+      '[raw image data (${object.lengthInBytes} bytes)]';
 }
 
 @freezed

--- a/flutter/packages/prompting_client/test/prompting_client_test.dart
+++ b/flutter/packages/prompting_client/test/prompting_client_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:grpc/grpc.dart';
 import 'package:mockito/annotations.dart';
@@ -23,6 +24,7 @@ void main() {
           storeUrl: 'storeUrl',
           publisher: 'publisher',
           updatedAt: '2024-07-13T10:57:28.34963269+02:00',
+          snapIcon: [1, 2, 3],
         ),
         requestedPath: '/home/user/Downloads/example.txt',
         homeDir: '/home/user',
@@ -56,6 +58,7 @@ void main() {
             storeUrl: 'storeUrl',
             publisher: 'publisher',
             updatedAt: DateTime.utc(2024, 7, 13, 8, 57, 28, 349, 632),
+            snapIcon: Uint8List.fromList([1, 2, 3]),
           ),
           requestedPath: '/home/user/Downloads/example.txt',
           homeDir: '/home/user',

--- a/prompting-client/build.rs
+++ b/prompting-client/build.rs
@@ -14,7 +14,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_server(true)
         .build_client(true)
         .out_dir("./src/protos")
-        .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(files, include_dirs)?;
 
     Ok(())

--- a/prompting-client/build.rs
+++ b/prompting-client/build.rs
@@ -14,6 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_server(true)
         .build_client(true)
         .out_dir("./src/protos")
+        .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(files, include_dirs)?;
 
     Ok(())

--- a/prompting-client/src/daemon/server.rs
+++ b/prompting-client/src/daemon/server.rs
@@ -509,7 +509,7 @@ mod tests {
                 store_url: "4".to_string(),
                 publisher: "5".to_string(),
                 updated_at: "3".to_string(),
-                snap_icon: None,
+                snap_icon: vec![],
             }),
             requested_path: "6".to_string(),
             home_dir: "7".to_string(),

--- a/prompting-client/src/daemon/server.rs
+++ b/prompting-client/src/daemon/server.rs
@@ -473,6 +473,7 @@ mod tests {
                 updated_at: "3".to_string(),
                 store_url: "4".to_string(),
                 publisher: "5".to_string(),
+                snap_icon: None,
             }),
         }
     }
@@ -485,6 +486,7 @@ mod tests {
                 updated_at: "3".to_string(),
                 store_url: "4".to_string(),
                 publisher: "5".to_string(),
+                snap_icon: None,
             },
             data: HomeUiInputData {
                 requested_path: "6".to_string(),
@@ -507,6 +509,7 @@ mod tests {
                 store_url: "4".to_string(),
                 publisher: "5".to_string(),
                 updated_at: "3".to_string(),
+                snap_icon: None,
             }),
             requested_path: "6".to_string(),
             home_dir: "7".to_string(),

--- a/prompting-client/src/lib.rs
+++ b/prompting-client/src/lib.rs
@@ -91,6 +91,9 @@ pub enum Error {
 
     #[error("unable to update log filter: {reason}")]
     UnableToUpdateLogFilter { reason: String },
+
+    #[error("snap replied with status code {status} but didn't provide a valid error response")]
+    InvalidSnapdErrorResponse { status: StatusCode },
 }
 
 /// Convenience Result type where E is an [Error] by default.

--- a/prompting-client/src/protos/apparmor_prompting.rs
+++ b/prompting-client/src/protos/apparmor_prompting.rs
@@ -191,8 +191,8 @@ pub struct MetaData {
     pub publisher: ::prost::alloc::string::String,
     #[prost(string, tag = "5")]
     pub updated_at: ::prost::alloc::string::String,
-    #[prost(bytes = "vec", optional, tag = "6")]
-    pub snap_icon: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "vec", tag = "6")]
+    pub snap_icon: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ResolveHomePatternTypeResponse {

--- a/prompting-client/src/protos/apparmor_prompting.rs
+++ b/prompting-client/src/protos/apparmor_prompting.rs
@@ -191,6 +191,8 @@ pub struct MetaData {
     pub publisher: ::prost::alloc::string::String,
     #[prost(string, tag = "5")]
     pub updated_at: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", optional, tag = "6")]
+    pub snap_icon: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ResolveHomePatternTypeResponse {

--- a/prompting-client/src/snapd_client/interfaces/camera.rs
+++ b/prompting-client/src/snapd_client/interfaces/camera.rs
@@ -97,7 +97,7 @@ impl SnapInterface for CameraInterface {
             snap_icon,
         } = input.meta;
 
-        let snap_icon = snap_icon.map(|icon| icon.0.into());
+        let snap_icon = snap_icon.map(|icon| icon.0.into()).unwrap_or(vec![]);
 
         Ok(ProtoPrompt::CameraPrompt(ProtoCameraPrompt {
             meta_data: Some(MetaData {

--- a/prompting-client/src/snapd_client/interfaces/camera.rs
+++ b/prompting-client/src/snapd_client/interfaces/camera.rs
@@ -78,6 +78,7 @@ impl SnapInterface for CameraInterface {
             updated_at: String::default(),
             store_url: String::default(),
             publisher: String::default(),
+            snap_icon: None,
         });
 
         Ok(UiInput {
@@ -93,7 +94,10 @@ impl SnapInterface for CameraInterface {
             updated_at,
             store_url,
             publisher,
+            snap_icon,
         } = input.meta;
+
+        let snap_icon = snap_icon.map(|icon| icon.0.into());
 
         Ok(ProtoPrompt::CameraPrompt(ProtoCameraPrompt {
             meta_data: Some(MetaData {
@@ -102,6 +106,7 @@ impl SnapInterface for CameraInterface {
                 store_url,
                 publisher,
                 updated_at,
+                snap_icon,
             }),
         }))
     }

--- a/prompting-client/src/snapd_client/interfaces/home.rs
+++ b/prompting-client/src/snapd_client/interfaces/home.rs
@@ -244,7 +244,7 @@ impl SnapInterface for HomeInterface {
             snap_icon,
         } = input.meta;
 
-        let snap_icon = snap_icon.map(|icon| icon.0.into());
+        let snap_icon = snap_icon.map(|icon| icon.0.into()).unwrap_or(vec![]);
 
         let HomeUiInputData {
             requested_path,

--- a/prompting-client/src/snapd_client/interfaces/home.rs
+++ b/prompting-client/src/snapd_client/interfaces/home.rs
@@ -208,6 +208,7 @@ impl SnapInterface for HomeInterface {
             updated_at: String::default(),
             store_url: String::default(),
             publisher: String::default(),
+            snap_icon: None,
         });
 
         // We elevate the suggested permissions in the ui from write -> read/write in order to
@@ -240,7 +241,10 @@ impl SnapInterface for HomeInterface {
             updated_at,
             store_url,
             publisher,
+            snap_icon,
         } = input.meta;
+
+        let snap_icon = snap_icon.map(|icon| icon.0.into());
 
         let HomeUiInputData {
             requested_path,
@@ -260,6 +264,7 @@ impl SnapInterface for HomeInterface {
                 store_url,
                 publisher,
                 updated_at,
+                snap_icon,
             }),
             requested_path,
             home_dir,

--- a/prompting-client/src/snapd_client/interfaces/microphone.rs
+++ b/prompting-client/src/snapd_client/interfaces/microphone.rs
@@ -97,7 +97,7 @@ impl SnapInterface for MicrophoneInterface {
             snap_icon,
         } = input.meta;
 
-        let snap_icon = snap_icon.map(|icon| icon.0.into());
+        let snap_icon = snap_icon.map(|icon| icon.0.into()).unwrap_or(vec![]);
 
         Ok(ProtoPrompt::MicrophonePrompt(ProtoMicrophonePrompt {
             meta_data: Some(MetaData {

--- a/prompting-client/src/snapd_client/interfaces/microphone.rs
+++ b/prompting-client/src/snapd_client/interfaces/microphone.rs
@@ -78,6 +78,7 @@ impl SnapInterface for MicrophoneInterface {
             updated_at: String::default(),
             store_url: String::default(),
             publisher: String::default(),
+            snap_icon: None,
         });
 
         Ok(UiInput {
@@ -93,7 +94,10 @@ impl SnapInterface for MicrophoneInterface {
             updated_at,
             store_url,
             publisher,
+            snap_icon,
         } = input.meta;
+
+        let snap_icon = snap_icon.map(|icon| icon.0.into());
 
         Ok(ProtoPrompt::MicrophonePrompt(ProtoMicrophonePrompt {
             meta_data: Some(MetaData {
@@ -102,6 +106,7 @@ impl SnapInterface for MicrophoneInterface {
                 store_url,
                 publisher,
                 updated_at,
+                snap_icon,
             }),
         }))
     }

--- a/prompting-client/src/snapd_client/mod.rs
+++ b/prompting-client/src/snapd_client/mod.rs
@@ -290,6 +290,7 @@ where
 
     /// Pull metadata for rendering apparmor prompts using the `snaps` snapd endpoint.
     pub async fn snap_metadata(&self, name: &str) -> Option<SnapMeta> {
+        let snap_icon = self.snap_icon(name).await;
         let res = self.client.get_json(&format!("snaps/{name}")).await;
         return match res {
             Ok(SnapDetails {
@@ -303,6 +304,7 @@ where
                     .unwrap_or(install_date),
                 store_url: format!("snap://{name}"),
                 publisher: publisher.display_name,
+                snap_icon,
             }),
 
             Err(e) => {
@@ -360,6 +362,7 @@ pub struct SnapMeta {
     pub updated_at: String,
     pub store_url: String,
     pub publisher: String,
+    pub snap_icon: Option<SnapIcon>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/prompting-client/src/snapd_client/response.rs
+++ b/prompting-client/src/snapd_client/response.rs
@@ -59,7 +59,7 @@ pub async fn parse_raw_response(res: Response<Incoming>) -> Result<Bytes> {
                 message,
                 err: Box::new(err),
             }),
-            Ok(()) => unreachable!(),
+            Ok(()) => Err(Error::InvalidSnapdErrorResponse { status }),
         };
     }
 

--- a/prompting-client/src/snapd_client/response.rs
+++ b/prompting-client/src/snapd_client/response.rs
@@ -1,6 +1,12 @@
 //! Parsing of snapd API responses
-use crate::{socket_client::body_json, Error, Result};
-use hyper::{body::Incoming, Response};
+use crate::{
+    socket_client::{body_json, body_raw},
+    Error, Result,
+};
+use hyper::{
+    body::{Bytes, Incoming},
+    Response, StatusCode,
+};
 use serde::{
     de::{self, DeserializeOwned, Deserializer},
     Deserialize, Serialize,
@@ -41,6 +47,23 @@ pub struct RuleConflict {
     pub(crate) permission: String,
     pub(crate) variant: String,
     pub(crate) conflicting_id: String,
+}
+
+pub async fn parse_raw_response(res: Response<Incoming>) -> Result<Bytes> {
+    let status = res.status();
+    if status != StatusCode::OK {
+        let response: SnapdResponse<()> = body_json(res).await?;
+        return match response.result {
+            Err((message, err)) => Err(Error::SnapdError {
+                status,
+                message,
+                err: Box::new(err),
+            }),
+            Ok(()) => unreachable!(),
+        };
+    }
+
+    body_raw(res).await
 }
 
 /// Parse a raw response body from snapd into our internal Result type

--- a/prompting-client/src/socket_client.rs
+++ b/prompting-client/src/socket_client.rs
@@ -99,3 +99,9 @@ where
 
     Ok(t)
 }
+
+pub(crate) async fn body_raw(res: Response<Incoming>) -> Result<Bytes> {
+    let bytes = res.into_body().collect().await.map(|buf| buf.to_bytes())?;
+
+    Ok(bytes)
+}

--- a/protos/apparmor-prompting.proto
+++ b/protos/apparmor-prompting.proto
@@ -152,6 +152,7 @@ message MetaData {
     string store_url = 3;
     string publisher = 4;
     string updated_at = 5;
+    optional bytes snap_icon = 6;
 }
 
 message ResolveHomePatternTypeResponse {

--- a/protos/apparmor-prompting.proto
+++ b/protos/apparmor-prompting.proto
@@ -152,7 +152,7 @@ message MetaData {
     string store_url = 3;
     string publisher = 4;
     string updated_at = 5;
-    optional bytes snap_icon = 6;
+    bytes snap_icon = 6;
 }
 
 message ResolveHomePatternTypeResponse {


### PR DESCRIPTION
Snap icons are retrieved from the `/v2/icons/{snap}/icon` API endpoint in snapd and sent to the UI via grpc alongside the other snap metadata.

UI for snaps with an icon:
<img width="1224" height="1018" alt="Screenshot From 2025-09-17 12-21-56" src="https://github.com/user-attachments/assets/9f73ce6f-66a0-4379-a93e-03fbc5e92598" />

UI for snaps without an icon (unchanged):
<img width="1224" height="1018" alt="Screenshot From 2025-09-17 12-22-49" src="https://github.com/user-attachments/assets/17534ad0-7fe8-45f8-8255-4781f2308d27" />



UDENG-7931