### PR TITLE
Fix desktop file Exec matching

### DIFF
--- a/snap/gui/daemon.desktop
+++ b/snap/gui/daemon.desktop
@@ -1,6 +1,9 @@
 [Desktop Entry]
 Type=Application
 Version=1.0
+# The Exec line is stripped by snapd, but while valid, snapcraft requires an Exec
+# https://github.com/canonical/snapcraft/issues/5799
+Exec=${SNAP}/bin/prompting-client-daemon
 Icon=${SNAP}/meta/gui/prompting-client.png
 Terminal=false
 NoDisplay=true


### PR DESCRIPTION
snapd 2.72 removes the env BAMF=… prefix to all its binaries in the Exec line. One consequence is that the desktop file becomes invalid. The Exec is generated by snapd is pointing to an unexisting binary (as it’s a systemd service and it doesn’t install in /snap/bin) and so, the file is ignored.

UDENG-8150