### PR TITLE
test: add integration tests for mock-server

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,3 +69,4 @@ jobs:
           cargo fmt -- --check
           cargo clippy -- -D warnings
           cargo test
+          cargo test --test mock_server --features dry-run

--- a/mock-server/README.md
+++ b/mock-server/README.md
@@ -175,7 +175,7 @@ For example:
 
 ```sh
 cd mock-server
-PIPE_PATH=/tmp/pip SOCKET_PATH=/tmp/mock.sock cargo run
+PIPE_PATH=/tmp/pipe SOCKET_PATH=/tmp/mock.sock cargo run
 ```
 
 The `SOCKET_PATH` must match the value passed to the prompting-client instance you want to test. Additionally, you need to set other override environment variables for the client in order to test it standalone:

--- a/mock-server/src/main.rs
+++ b/mock-server/src/main.rs
@@ -46,6 +46,7 @@ async fn main() -> Result<()> {
 
     let pipe_path = std::env::var("PIPE_PATH")?;
     let socket_path = std::env::var("SOCKET_PATH")?;
+    let prompts_path = std::env::var("PROMPTS_PATH").unwrap_or("prompts".into());
 
     // A broadcast channel is used instead of a standard mpsc channel because it allows
     // multiple receivers to subscribe and receive all messages sent through the channel.
@@ -53,7 +54,7 @@ async fn main() -> Result<()> {
     // to multiple independent consumers.
     let (tx, _) = broadcast::channel::<(Value, Action)>(16);
 
-    let prompts = Prompts::read_initial_state("prompts");
+    let prompts = Prompts::read_initial_state(&prompts_path);
     let mut notices = HashMap::new();
     for k in prompts.keys() {
         let value = Prompts::make_notice(k.parse::<u64>()?, k);

--- a/prompting-client/Cargo.toml
+++ b/prompting-client/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = "1.0.117"
 serde = { version = "1.0.202", features = ["derive"] }
 strum = { version = "0.27.0", features = ["derive"] }
 thiserror = "1.0.61"
-tokio-stream = "0.1.15"
+tokio-stream = { version = "0.1.15", features = ["io-util"] }
 tokio = { version = "1.43.1", features = [
     "fs",
     "io-util",

--- a/prompting-client/tests/integration.rs
+++ b/prompting-client/tests/integration.rs
@@ -6,6 +6,9 @@
 //!
 //! Creation of the SnapdSocketClient needs to be handled before spawning the test snap so that
 //! polling `after` is correct to pick up the prompt.
+
+#![cfg(not(feature = "dry-run"))]
+
 use prompting_client::{
     cli_actions::ScriptedClient,
     prompt_sequence::MatchError,

--- a/prompting-client/tests/mock_server.rs
+++ b/prompting-client/tests/mock_server.rs
@@ -1,0 +1,280 @@
+//! Integration tests to verify mock-server is in sync and works with the client implementation
+//! These tests require the 'dry-run' feature to be enabled: cargo test --features dry-run
+
+#![cfg(feature = "dry-run")]
+
+use prompting_client::{
+    snapd_client::{
+        interfaces::{
+            camera::CameraInterface, home::HomeInterface, microphone::MicrophoneInterface,
+            SnapInterface,
+        },
+        Action, SnapdSocketClient, TypedPrompt,
+    },
+    Result,
+};
+use serial_test::serial;
+use simple_test_case::test_case;
+use std::{env, path::PathBuf, process::Stdio, sync::OnceLock, time::Duration};
+use tokio::{
+    fs::File,
+    io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
+    process::Command,
+    spawn,
+    sync::mpsc::{unbounded_channel, UnboundedReceiver},
+    time::sleep,
+};
+use tokio_stream::{wrappers::LinesStream, StreamExt};
+
+static PIPE_PATH: OnceLock<String> = OnceLock::new();
+static SOCKET_PATH: OnceLock<String> = OnceLock::new();
+static PROMPTS_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+fn get_pipe_path() -> &'static str {
+    PIPE_PATH.get_or_init(|| format!("/tmp/pipe.{}", uuid::Uuid::new_v4()))
+}
+
+fn get_socket_path() -> &'static str {
+    SOCKET_PATH.get_or_init(|| format!("/tmp/mock.sock.{}", uuid::Uuid::new_v4()))
+}
+
+fn get_prompts_path() -> &'static PathBuf {
+    PROMPTS_PATH.get_or_init(|| {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let workspace_root = std::path::Path::new(manifest_dir)
+            .parent()
+            .expect("CARGO_MANIFEST_DIR should have a parent directory (workspace root)");
+
+        workspace_root.join("mock-server/prompts")
+    })
+}
+
+fn get_mock_server_path() -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(manifest_dir)
+        .parent()
+        .expect("CARGO_MANIFEST_DIR should have a parent directory (workspace root)");
+    let mock_server_path = workspace_root.join("mock-server");
+
+    let binary_path = mock_server_path.join("target/release/mock-server");
+    if !binary_path.exists() {
+        let output = std::process::Command::new("cargo")
+            .args(&["build", "--release"])
+            .current_dir(&mock_server_path)
+            .output()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to execute 'cargo build --release' in directory {:?}: {}",
+                    mock_server_path, e
+                )
+            });
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            panic!(
+                "Failed to build mock-server in directory {:?}\nExit code: {:?}\nStdout:\n{}\nStderr:\n{}",
+                mock_server_path, output.status.code(), stdout, stderr
+            );
+        }
+    }
+
+    binary_path
+}
+
+fn start_mock_server() -> UnboundedReceiver<String> {
+    env::set_var("SNAPD_SOCKET_OVERRIDE", get_socket_path());
+
+    let (tx, rx) = unbounded_channel();
+    let binary_path = get_mock_server_path();
+
+    spawn(async move {
+        let mut c = Command::new(&binary_path)
+            .env("PIPE_PATH", get_pipe_path())
+            .env("SOCKET_PATH", get_socket_path())
+            .env("PROMPTS_PATH", get_prompts_path())
+            .env("RUST_LOG", "info")
+            .stdout(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .unwrap_or_else(|e| {
+                panic!("Failed to start mock server from {:?}: {}", binary_path, e)
+            });
+
+        let stdout = BufReader::new(
+            c.stdout
+                .as_mut()
+                .expect("Mock server stdout should be available"),
+        );
+        let mut stdout_lines = LinesStream::new(stdout.lines());
+
+        while let Some(Ok(line)) = stdout_lines.next().await {
+            if ["Get", "Reply", "Sending", "New"]
+                .iter()
+                .any(|&pattern| line.contains(pattern))
+            {
+                if let Err(_) = tx.send(line) {
+                    break;
+                }
+            }
+        }
+    });
+
+    rx
+}
+
+macro_rules! reply {
+    ($client:expr, $id:expr, $prompt:expr, $action:expr) => {
+        match $prompt {
+            TypedPrompt::Camera(_) => {
+                $client
+                    .reply_to_prompt(
+                        $id,
+                        CameraInterface::prompt_to_reply($prompt.try_into()?, $action).into(),
+                    )
+                    .await?
+            }
+            TypedPrompt::Home(_) => {
+                $client
+                    .reply_to_prompt(
+                        $id,
+                        HomeInterface::prompt_to_reply($prompt.try_into()?, $action).into(),
+                    )
+                    .await?
+            }
+            TypedPrompt::Microphone(_) => {
+                $client
+                    .reply_to_prompt(
+                        $id,
+                        MicrophoneInterface::prompt_to_reply($prompt.try_into()?, $action).into(),
+                    )
+                    .await?
+            }
+        }
+    };
+}
+
+#[tokio::test]
+#[serial]
+async fn ensure_prompting_is_enabled() -> Result<()> {
+    let _rx = start_mock_server();
+
+    // wait for the mock server to start
+    sleep(Duration::from_millis(100)).await;
+
+    let c = SnapdSocketClient::new().await;
+    assert!(c.is_prompting_enabled().await?, "prompting is not enabled");
+
+    Ok(())
+}
+
+#[test_case(Action::Allow; "allow")]
+#[test_case(Action::Deny; "deny")]
+#[tokio::test]
+#[serial]
+async fn all_initial_state_prompts_are_valid(action: Action) -> Result<()> {
+    let mut rx = start_mock_server();
+
+    // wait for the mock server to start
+    sleep(Duration::from_millis(100)).await;
+
+    let c = SnapdSocketClient::new().await;
+
+    let pending = c.all_pending_prompt_details().await?;
+    assert_eq!(pending.len(), 4, "expected 4 prompts");
+
+    let log = rx.recv().await;
+    assert!(log.is_some_and(|l| l.contains("Get current pending prompts")));
+
+    for p in pending {
+        let id = p.id();
+        let p = c.prompt_details(&id).await?;
+
+        let log = rx.recv().await;
+        assert!(log.is_some_and(|l| l.contains(&format!("Get pending prompt: {}", id.0))));
+
+        reply!(c, id, p, action);
+
+        let log = rx.recv().await;
+        assert!(log.is_some_and(|l| l.contains(&format!("Reply to prompt {}", id.0))));
+    }
+
+    let pending = c.all_pending_prompt_details().await?;
+    assert_eq!(pending.len(), 0, "expected no prompt");
+
+    Ok(())
+}
+
+#[test_case(Action::Allow; "allow")]
+#[test_case(Action::Deny; "deny")]
+#[tokio::test]
+#[serial]
+async fn send_through_pipe(action: Action) -> Result<()> {
+    let prompt = serde_json::json!({
+        "id": "0000000000000000",
+        "timestamp": "2025-08-20T16:17:44.28198468+02:00",
+        "snap": "foo",
+        "pid": 136211,
+        "interface": "camera",
+        "constraints": {
+            "requested-permissions": [
+                "access"
+            ],
+            "available-permissions": [
+                "access"
+            ]
+        }
+    });
+
+    let mut rx = start_mock_server();
+
+    // wait for the mock server to start
+    sleep(Duration::from_millis(100)).await;
+
+    spawn(async move {
+        sleep(Duration::from_millis(5)).await;
+
+        let pipe: File = File::options().write(true).open(get_pipe_path()).await?;
+        let mut writer = BufWriter::new(pipe);
+
+        let content = serde_json::to_string(&prompt)?;
+
+        writer.write_all(content.as_bytes()).await?;
+        writer.flush().await?;
+
+        Ok::<(), io::Error>(())
+    });
+
+    let mut c = SnapdSocketClient::new().await;
+    c.pending_prompt_notices().await?;
+
+    let log = rx.recv().await;
+    assert!(log.is_some_and(|l| l.contains("New listener to the long polling api")));
+
+    let log = rx.recv().await;
+    assert!(log.is_some_and(|l| l.contains("Sending data into the pipe")));
+
+    let pending = c.all_pending_prompt_details().await?;
+    assert_eq!(pending.len(), 5, "expected 5 prompts");
+
+    let log = rx.recv().await;
+    assert!(log.is_some_and(|l| l.contains("Get current pending prompts")));
+
+    for p in pending {
+        let id = p.id();
+        let p = c.prompt_details(&id).await?;
+
+        let log = rx.recv().await;
+        assert!(log.is_some_and(|l| l.contains(&format!("Get pending prompt: {}", id.0))));
+
+        reply!(c, id, p, action);
+
+        let log = rx.recv().await;
+        assert!(log.is_some_and(|l| l.contains(&format!("Reply to prompt {}", id.0))));
+    }
+
+    let pending = c.all_pending_prompt_details().await?;
+    assert_eq!(pending.len(), 0, "expected no prompt");
+
+    Ok(())
+}


### PR DESCRIPTION
In order to maintain the mock server consistent with the client codebase and snapd API modifications, we need CI tests

---

[UDENG-7918](https://warthogs.atlassian.net/browse/UDENG-7918)

[UDENG-7918]: https://warthogs.atlassian.net/browse/UDENG-7918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ