### PR TITLE
fix: exit with failure if a task ends

### DIFF
--- a/prompting-client/src/daemon/poll.rs
+++ b/prompting-client/src/daemon/poll.rs
@@ -8,7 +8,7 @@ use crate::{
     daemon::{EnrichedPrompt, PromptUpdate},
     exit_with,
     snapd_client::{PromptId, PromptNotice, SnapMeta, SnapdSocketClient, TypedPrompt},
-    Error, ExitStatus,
+    Error, ExitStatus, Result,
 };
 use cached::proc_macro::cached;
 use hyper::StatusCode;
@@ -58,7 +58,7 @@ impl PollLoop {
     /// we are running under and processes them before dropping into long-polling for notices.
     /// This task is responsible for pulling prompt details and snap meta-data from snapd but
     /// does not directly process the prompts themselves.
-    pub async fn run(mut self) {
+    pub async fn run(mut self) -> Result<()> {
         if !self.skip_outstanding_prompts {
             self.handle_outstanding_prompts().await;
         }
@@ -103,6 +103,8 @@ impl PollLoop {
                 }
             }
         }
+
+        Ok(())
     }
 
     fn send_update(&mut self, update: PromptUpdate) {

--- a/prompting-client/src/lib.rs
+++ b/prompting-client/src/lib.rs
@@ -41,6 +41,9 @@ pub enum Error {
     HyperHttp(#[from] hyper::http::Error),
 
     #[error(transparent)]
+    TonicTransport(#[from] tonic::transport::Error),
+
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 
     #[error(transparent)]


### PR DESCRIPTION
Currently it is possible that one of the tokio tasks (worker loop, poll loop, grpc server) exits due to an error, but the daemon keeps running. In this case prompts can no longer be actioned by the user. If that happens, we should make sure the daemon exits with a failure status, so that systemd restarts it.

UDENG-8228