### PR TITLE
feat: check if prompting is enabled on poll timeout

### DIFF
--- a/prompting-client/src/daemon/poll.rs
+++ b/prompting-client/src/daemon/poll.rs
@@ -83,6 +83,7 @@ impl PollLoop {
 
                 Err(error) if retries < MAX_POLL_RETRIES => {
                     error!(%error, "unable to pull prompt ids: retrying");
+                    self.client.exit_if_prompting_not_enabled().await?;
                     sleep(RETRY_SLEEP_DURATION).await;
                     retries += 1;
                     continue;


### PR DESCRIPTION
This makes sure the prompting-client exits when the prompting feature is turned off.