### PR TITLE
fix: remove blocking channel send from spawn_for_output

### DIFF
--- a/prompting-client/tests/integration.rs
+++ b/prompting-client/tests/integration.rs
@@ -28,14 +28,13 @@ use std::{
     io::{self, ErrorKind},
     os::unix::fs::PermissionsExt,
     process::Stdio,
-    sync::mpsc::{Receiver, channel},
     time::Duration,
 };
 use tokio::{
-    io::{AsyncReadExt, BufReader},
     process::Command,
     runtime::Runtime,
     spawn,
+    task::JoinHandle,
     time::{sleep, timeout},
 };
 use uuid::Uuid;
@@ -102,9 +101,7 @@ impl TestFixture {
             .clone()
     }
 
-    fn spawn_for_output(&self, cmd: &'static str, args: Vec<String>) -> Receiver<Output> {
-        let (tx, rx) = channel();
-
+    fn spawn_for_output(&self, cmd: &'static str, args: Vec<String>) -> JoinHandle<Output> {
         spawn(async move {
             let mut c = Command::new(cmd);
             c.args(args)
@@ -112,33 +109,22 @@ impl TestFixture {
                 .stderr(Stdio::piped())
                 .kill_on_drop(true);
 
-            let mut c = c.spawn().expect("spawn process");
-
-            let stdout_reader = c.stdout.take().map(BufReader::new);
-            let stderr_reader = c.stderr.take().map(BufReader::new);
-
-            let (stdout, stderr) = match timeout(TIMEOUT, c.wait()).await {
-                Ok(Ok(_)) => {
-                    let mut stdout = String::new();
-                    if let Some(mut reader) = stdout_reader {
-                        reader.read_to_string(&mut stdout).await.ok();
-                    }
-
-                    let mut stderr = String::new();
-                    if let Some(mut reader) = stderr_reader {
-                        reader.read_to_string(&mut stderr).await.ok();
-                    }
-
-                    (stdout, stderr)
-                }
-                Ok(Err(e)) => (String::new(), format!("Process exited with error: {e}")),
-                Err(_) => (String::new(), "Process timed out".to_string()),
-            };
-
-            tx.send(Output { stdout, stderr }).expect("send to succeed");
-        });
-
-        rx
+            let child = c.spawn().expect("spawn process");
+            match timeout(TIMEOUT, child.wait_with_output()).await {
+                Ok(Ok(output)) => Output {
+                    stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                    stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                },
+                Ok(Err(e)) => Output {
+                    stdout: String::new(),
+                    stderr: format!("Process exited with error: {e}"),
+                },
+                Err(_) => Output {
+                    stdout: String::new(),
+                    stderr: "Process timed out".to_string(),
+                },
+            }
+        })
     }
 }
 
@@ -267,7 +253,10 @@ async fn camera_interface_connected(
     )
     .await?;
 
-    let output = rx.recv_timeout(TIMEOUT).expect("to be able to recv");
+    let output = timeout(TIMEOUT, rx)
+        .await
+        .expect("to be able to recv")
+        .expect("join to succeed");
 
     assert_eq!(output.stdout, expected_stdout, "stdout");
     assert_eq!(
@@ -302,7 +291,10 @@ async fn camera_interface_connected_naive(
     )
     .await?;
 
-    let output = rx.recv_timeout(TIMEOUT).expect("to be able to recv");
+    let output = timeout(TIMEOUT, rx)
+        .await
+        .expect("to be able to recv")
+        .expect("join to succeed");
 
     assert_eq!(
         output.stdout,
@@ -343,7 +335,10 @@ async fn microphone_interface_connected(
     )
     .await?;
 
-    let output = rx.recv_timeout(TIMEOUT).expect("to be able to recv");
+    let output = timeout(TIMEOUT, rx)
+        .await
+        .expect("to be able to recv")
+        .expect("join to succeed");
 
     assert_eq!(output.stdout, expected_stdout, "stdout");
     assert_eq!(
@@ -376,7 +371,10 @@ async fn happy_path_read_single(
         HomeInterface::prompt_to_reply(p.try_into()?, action).into(),
     )
     .await?;
-    let output = rx.recv_timeout(TIMEOUT).expect("to be able recv");
+    let output = timeout(TIMEOUT, rx)
+        .await
+        .expect("to be able to recv")
+        .expect("join to succeed");
 
     assert_eq!(output.stdout, expected_stdout, "stdout");
     assert_eq!(
@@ -605,7 +603,10 @@ async fn replying_multiple_times_errors(
         HomeInterface::prompt_to_reply(p.clone(), action).into(),
     )
     .await?;
-    let output = rx.recv_timeout(TIMEOUT).expect("to be able recv");
+    let output = timeout(TIMEOUT, rx)
+        .await
+        .expect("to be able to recv")
+        .expect("join to succeed");
 
     assert_eq!(output.stdout, expected_stdout, "stdout");
     assert_eq!(
@@ -663,7 +664,10 @@ async fn overwriting_a_file_works() -> Result<()> {
         vec![test.prefix(), "after".to_string()],
     );
     sleep(Duration::from_millis(300)).await;
-    let output = rx.recv_timeout(TIMEOUT).expect("to be able recv");
+    let output = timeout(TIMEOUT, rx)
+        .await
+        .expect("to be able to recv")
+        .expect("join to succeed");
     assert_eq!(output.stdout, "done\n");
     assert_eq!(output.stderr, "");
 

--- a/prompting-client/tests/integration.rs
+++ b/prompting-client/tests/integration.rs
@@ -244,7 +244,7 @@ async fn camera_interface_connected(
     let test = TestFixture::new();
     let mut c = SnapdSocketClient::new().await;
 
-    let rx = test.spawn_for_output("aa-prompting-test.camera", vec![device.into()]);
+    let handle = test.spawn_for_output("aa-prompting-test.camera", vec![device.into()]);
     let (id, p) = expect_single_prompt!(&mut c, "", &["access"]).await;
 
     c.reply_to_prompt(
@@ -253,7 +253,7 @@ async fn camera_interface_connected(
     )
     .await?;
 
-    let output = timeout(TIMEOUT, rx)
+    let output = timeout(TIMEOUT, handle)
         .await
         .expect("to be able to recv")
         .expect("join to succeed");
@@ -282,7 +282,7 @@ async fn camera_interface_connected_naive(
     let mut c = SnapdSocketClient::new().await;
     let test = TestFixture::new();
 
-    let rx = test.spawn_for_output("aa-prompting-test.camera-naive", vec![device.into()]);
+    let handle = test.spawn_for_output("aa-prompting-test.camera-naive", vec![device.into()]);
     let (id, p) = expect_single_prompt!(&mut c, "", &["access"]).await;
 
     c.reply_to_prompt(
@@ -291,7 +291,7 @@ async fn camera_interface_connected_naive(
     )
     .await?;
 
-    let output = timeout(TIMEOUT, rx)
+    let output = timeout(TIMEOUT, handle)
         .await
         .expect("to be able to recv")
         .expect("join to succeed");
@@ -326,7 +326,7 @@ async fn microphone_interface_connected(
     let test = TestFixture::new();
     let mut c = SnapdSocketClient::new().await;
 
-    let rx = test.spawn_for_output("aa-prompting-test.microphone", vec![device.into()]);
+    let handle = test.spawn_for_output("aa-prompting-test.microphone", vec![device.into()]);
     let (id, p) = expect_single_prompt!(&mut c, "", &["access"]).await;
 
     c.reply_to_prompt(
@@ -335,7 +335,7 @@ async fn microphone_interface_connected(
     )
     .await?;
 
-    let output = timeout(TIMEOUT, rx)
+    let output = timeout(TIMEOUT, handle)
         .await
         .expect("to be able to recv")
         .expect("join to succeed");
@@ -362,7 +362,7 @@ async fn happy_path_read_single(
     let mut c = SnapdSocketClient::new().await;
     let test = TestFixture::with_test_dir(None, &[("test.txt", expected_stdout)])?;
 
-    let rx = test.spawn_for_output("aa-prompting-test.read", vec![test.prefix()]);
+    let handle = test.spawn_for_output("aa-prompting-test.read", vec![test.prefix()]);
     let (id, p) =
         expect_single_prompt!(&mut c, &format!("{}/test.txt", test.path()), &["read"]).await;
 
@@ -371,7 +371,7 @@ async fn happy_path_read_single(
         HomeInterface::prompt_to_reply(p.try_into()?, action).into(),
     )
     .await?;
-    let output = timeout(TIMEOUT, rx)
+    let output = timeout(TIMEOUT, handle)
         .await
         .expect("to be able to recv")
         .expect("join to succeed");
@@ -400,7 +400,7 @@ async fn happy_path_create_multiple(action: Action, lifespan: Lifespan) -> Resul
     let mut c = SnapdSocketClient::new().await;
     let test = TestFixture::with_test_dir(None, &[])?;
 
-    let _rx = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
+    let _handle = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
     let path = format!("{}/test-1.txt", test.path());
     let (id, p) = expect_single_prompt!(&mut c, &path, &["write"]).await;
     let mut reply = HomeInterface::prompt_to_reply(p.try_into()?, action)
@@ -449,12 +449,12 @@ async fn happy_path_create_multiple(action: Action, lifespan: Lifespan) -> Resul
 async fn create_multiple_actioned_by_other_pid(action: Action, lifespan: Lifespan) -> Result<()> {
     let test = TestFixture::with_test_dir(None, &[])?;
 
-    let _rx = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
+    let _handle = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
     sleep(Duration::from_millis(400)).await;
 
     let mut c = SnapdSocketClient::new().await;
 
-    let _rx = test.spawn_for_output(
+    let _handle = test.spawn_for_output(
         "aa-prompting-test.create-single",
         vec![test.prefix(), "test\n".to_string()],
     );
@@ -526,7 +526,7 @@ async fn incorrect_custom_paths_error(reply_path: &str, expected_prefix: &str) -
     let mut c = SnapdSocketClient::new().await;
     let test = TestFixture::with_test_dir(None, &[("test.txt", "test")])?;
 
-    let _rx = test.spawn_for_output("aa-prompting-test.read", vec![test.prefix()]);
+    let _handle = test.spawn_for_output("aa-prompting-test.read", vec![test.prefix()]);
     let (id, p) =
         expect_single_prompt!(&mut c, &format!("{}/test.txt", test.path()), &["read"]).await;
     let reply = HomeInterface::prompt_to_reply(p.try_into()?, Action::Allow)
@@ -558,7 +558,7 @@ async fn invalid_timeperiod_duration_errors(timespan: &str, expected_prefix: &st
     let mut c = SnapdSocketClient::new().await;
     let test = TestFixture::with_test_dir(None, &[("test.txt", "test")])?;
 
-    let _rx = test.spawn_for_output("aa-prompting-test.read", vec![test.prefix()]);
+    let _handle = test.spawn_for_output("aa-prompting-test.read", vec![test.prefix()]);
     let (id, p) =
         expect_single_prompt!(&mut c, &format!("{}/test.txt", test.path()), &["read"]).await;
     let reply = HomeInterface::prompt_to_reply(p.try_into()?, Action::Allow)
@@ -591,7 +591,7 @@ async fn replying_multiple_times_errors(
     let mut c = SnapdSocketClient::new().await;
     let test = TestFixture::with_test_dir(None, &[("test.txt", expected_stdout)])?;
 
-    let rx = test.spawn_for_output("aa-prompting-test.read", vec![test.prefix()]);
+    let handle = test.spawn_for_output("aa-prompting-test.read", vec![test.prefix()]);
     let (id, p) =
         expect_single_prompt!(&mut c, &format!("{}/test.txt", test.path()), &["read"]).await;
 
@@ -603,7 +603,7 @@ async fn replying_multiple_times_errors(
         HomeInterface::prompt_to_reply(p.clone(), action).into(),
     )
     .await?;
-    let output = timeout(TIMEOUT, rx)
+    let output = timeout(TIMEOUT, handle)
         .await
         .expect("to be able to recv")
         .expect("join to succeed");
@@ -642,7 +642,7 @@ async fn overwriting_a_file_works() -> Result<()> {
     let mut c = SnapdSocketClient::new().await;
     let test = TestFixture::with_test_dir(None, &[])?;
 
-    let rx = test.spawn_for_output(
+    let handle = test.spawn_for_output(
         "aa-prompting-test.create-single",
         vec![test.prefix(), "before".to_string()],
     );
@@ -659,12 +659,12 @@ async fn overwriting_a_file_works() -> Result<()> {
     assert_eq!(res.expect("file should exist"), "before");
 
     // Not expecting another prompt due to previous allow always reply
-    let _rx = test.spawn_for_output(
+    let _handle = test.spawn_for_output(
         "aa-prompting-test.create-single",
         vec![test.prefix(), "after".to_string()],
     );
     sleep(Duration::from_millis(300)).await;
-    let output = timeout(TIMEOUT, rx)
+    let output = timeout(TIMEOUT, handle)
         .await
         .expect("to be able to recv")
         .expect("join to succeed");
@@ -686,7 +686,7 @@ async fn scripted_client_works_with_simple_matching() -> Result<()> {
     let mut c = SnapdSocketClient::new().await;
     let test = TestFixture::with_test_dir(None, &[("seq.json", seq)])?;
 
-    let _rx = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
+    let _handle = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
 
     let mut scripted_client = ScriptedClient::try_new(
         format!("{}/seq.json", test.path()),
@@ -725,7 +725,7 @@ async fn invalid_prompt_sequence_reply_errors() -> Result<()> {
     let mut c = SnapdSocketClient::new().await;
     let test = TestFixture::with_test_dir(None, &[("seq.json", seq)])?;
 
-    let _rx = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
+    let _handle = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
 
     let mut scripted_client = ScriptedClient::try_new(
         format!("{}/seq.json", test.path()),
@@ -762,7 +762,7 @@ async fn unexpected_prompt_in_sequence_errors() -> Result<()> {
     let mut c = SnapdSocketClient::new().await;
     let test = TestFixture::with_test_dir(None, &[("seq.json", seq)])?;
 
-    let _rx = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
+    let _handle = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
     let mut scripted_client = ScriptedClient::try_new(
         format!("{}/seq.json", test.path()),
         &[("BASE_PATH", &test.path())],
@@ -797,7 +797,7 @@ async fn prompt_after_a_sequence_with_grace_period_errors() -> Result<()> {
     let mut c = SnapdSocketClient::new().await;
     let test = TestFixture::with_test_dir(None, &[("seq.json", seq)])?;
 
-    let _rx = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
+    let _handle = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
     let mut scripted_client = ScriptedClient::try_new(
         format!("{}/seq.json", test.path()),
         &[("BASE_PATH", &test.path())],
@@ -828,7 +828,7 @@ async fn prompt_after_a_sequence_without_grace_period_is_ok() -> Result<()> {
 
     let mut c = SnapdSocketClient::new().await;
 
-    let _rx = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
+    let _handle = test.spawn_for_output("aa-prompting-test.create", vec![test.prefix()]);
     let mut scripted_client = ScriptedClient::try_new(
         format!("{}/seq.json", test.path()),
         &[("BASE_PATH", &test.path())],


### PR DESCRIPTION
Previously, `spawn_for_output` would wait for the subprocess which triggered a prompt to finish, then manually read the stdout and stderr pipes before sending the output over a MPSC channel. This seemed to be the cause of tests sometimes hanging after the subprocess exited.

In particular, with the prompting notice backend enabled in snapd, the prompting-client integration tests consistently hang, e.g. `happy_path_read_single`, which hangs after the successful POST of the reply to the prompt. At that point, the triggering process ought to finish and let the test succeed, but for some reason, the tests hang. The PR to enable the prompting notice backend in snapd can be found at https://github.com/canonical/snapd/pull/16303

This PR replaces the manual wait and reading of stdout/stderr with instead calling `wait_with_output` and directly using the resulting output stdout/stderr, without a separate reader. Then, importantly, rather than sending the output over a MPSC, `spawn_for_output` now returns a `JoinHandle` directly. This means that callers no longer have a blocking `recv` call from a MPSC channel; instead, they await the output of the subprocess thread handle, using a tokio timeout. This prevents the test from hanging as a result of the tokio scheduler, regardless of the order in which processes interact and how quickly snapd reacts.