### PR TITLE
fix(clippy): refactor after clippy rules update in rust stable

### DIFF
--- a/prompting-client/src/daemon/worker.rs
+++ b/prompting-client/src/daemon/worker.rs
@@ -271,7 +271,7 @@ where
             Err(err) => err.into_inner(),
         };
 
-        for (_, active_prompt) in guard.iter_mut() {
+        for active_prompt in guard.values_mut() {
             if active_prompt.typed_ui_input.id() == &id {
                 active_prompt.ui_handle.take();
             }


### PR DESCRIPTION
Refactor the code in the worker module to align with the latest Clippy linting rules in Rust stable.